### PR TITLE
OPE-3118 Introduce deep copy macro

### DIFF
--- a/UnityProject/CspUnityTests/Assets/Scripts/IntegrationTests/EventTests.cs
+++ b/UnityProject/CspUnityTests/Assets/Scripts/IntegrationTests/EventTests.cs
@@ -1,0 +1,315 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using csp.systems;
+using LoginTokenInfoResult = csp.systems.LoginTokenInfoResult;
+
+namespace Magnopus.Foundation.Unity.Tests.Integration
+{
+    public class EventTests : FoundationFixture
+    {
+#if UNITY_EDITOR
+        private UserSystem userSystem;
+        private List<string> eventLog;
+        private LoginTokenInfoResult capturedTokenResult;
+        private bool tokenEventFired;
+        
+        private const string onNewLoginTokenReceivedFieldName = "_onNewLoginTokenReceived";
+
+        protected override void FoundationFixtureSetup()
+        {
+            settings = new FoundationFixtureSettings
+            {
+                InitializeFoundationFixtureOnOneTimeSetup = true,
+                StartFoundation = true,
+                CreatePrimaryAccount = false,
+                Login = false
+            };
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            eventLog = new List<string>();
+            capturedTokenResult = null;
+            tokenEventFired = false;
+            
+            if (isInitialized)
+            {
+                userSystem = SystemsManager.Get().GetUserSystem();
+                Assert.IsNotNull(userSystem, "UserSystem should be available after initialization.");
+            }
+            else
+            {
+                Assert.Ignore("Foundation not initialized - skipping event tests");
+            }
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            // Clean up any subscriptions to prevent cross-test contamination
+            if (userSystem != null)
+            {
+                // Try to clear backing delegates via reflection (events cannot be assigned directly)
+                var userSystemType = typeof(UserSystem);
+                var fi = userSystemType.GetField(onNewLoginTokenReceivedFieldName, 
+                    BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                if (fi != null)
+                {
+                    fi.SetValue(userSystem, null);
+                    return;
+                }
+
+                Debug.LogWarning(
+                    $"Could not find backing field '{onNewLoginTokenReceivedFieldName}' to clear event subscriptions." +
+                    $" Subscriptions may persist between tests.");
+            }
+        }
+
+        /// <summary>
+        /// Helper method to invoke a UserSystem event using reflection.
+        /// This fires the internal event delegate to simulate the event being triggered by the system.
+        /// </summary>
+        private void FireLoginTokenEvent(LoginTokenInfoResult result)
+        {
+            var userSystemType = typeof(UserSystem);
+            var eventField = userSystemType.GetField(
+                onNewLoginTokenReceivedFieldName, 
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.IgnoreCase);
+            
+            if (eventField != null)
+            {
+                try
+                {
+                    var target = eventField.GetValue(userSystem);
+                    if (target is Delegate del)
+                    {
+                        del.DynamicInvoke(result);
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogWarning($"Failed to invoke OnNewLoginTokenReceived via field '{onNewLoginTokenReceivedFieldName}': {ex.Message}");
+                }
+            }
+            Debug.LogWarning("Could not find OnNewLoginTokenReceived backing field. Event handlers will not be invoked.");
+        }
+
+        /// <summary>
+        /// Tests that OnNewLoginTokenReceived event can be subscribed to and fires with correct data.
+        /// </summary>
+        [Test]
+        public void OnNewLoginTokenReceived_Subscribe_EventFiresWithCorrectData()
+        {
+            var handlerCalled = false;
+
+            void TokenReceivedHandler(LoginTokenInfoResult result)
+            {
+                handlerCalled = true;
+                tokenEventFired = true;
+                capturedTokenResult = result;
+                eventLog.Add("TokenReceived");
+            }
+            
+            // Subscribe to the real event
+            userSystem.OnNewLoginTokenReceived += TokenReceivedHandler;
+
+            // Create test data and fire the event using an uninitialized instance to avoid invoking internal constructors
+            var tokenResultObj = System.Runtime.Serialization.FormatterServices.GetUninitializedObject(typeof(LoginTokenInfoResult)) as LoginTokenInfoResult;
+            FireLoginTokenEvent(tokenResultObj);
+            
+            Assert.IsTrue(handlerCalled, "Handler should have been called.");
+            Assert.IsTrue(tokenEventFired, "Event flag should be set.");
+            Assert.IsNotNull(capturedTokenResult, "Token result should be captured.");
+            Assert.IsTrue(eventLog.Contains("TokenReceived"), "Event log should contain token receipt message.");
+        }
+
+        /// <summary>
+        /// Tests that multiple handlers can be subscribed to OnNewLoginTokenReceived event and all are fired.
+        /// </summary>
+        [Test]
+        public void OnNewLoginTokenReceived_MultipleHandlers_AllAreFired()
+        {
+            var handler1Called = false;
+            var handler2Called = false;
+            var handler3Called = false;
+
+            void Handler1(LoginTokenInfoResult result)
+            {
+                handler1Called = true;
+                eventLog.Add("Handler1");
+            }
+            void Handler2(LoginTokenInfoResult result)
+            {
+                handler2Called = true;
+                eventLog.Add("Handler2");
+            }
+            void Handler3(LoginTokenInfoResult result)
+            {
+                handler3Called = true;
+                eventLog.Add("Handler3");
+            }
+            
+            // Subscribe multiple handlers
+            userSystem.OnNewLoginTokenReceived += Handler1;
+            userSystem.OnNewLoginTokenReceived += Handler2;
+            userSystem.OnNewLoginTokenReceived += Handler3;
+
+            // Fire the event
+            var tokenResult = System.Runtime.Serialization.FormatterServices.GetUninitializedObject(typeof(LoginTokenInfoResult)) as LoginTokenInfoResult;
+            FireLoginTokenEvent(tokenResult);
+            
+            Assert.IsTrue(handler1Called, "Handler1 should have been called.");
+            Assert.IsTrue(handler2Called, "Handler2 should have been called.");
+            Assert.IsTrue(handler3Called, "Handler3 should have been called.");
+            Assert.AreEqual(3, eventLog.Count, "All three handlers should have logged their execution.");
+            Assert.Contains("Handler1", eventLog);
+            Assert.Contains("Handler2", eventLog);
+            Assert.Contains("Handler3", eventLog);
+        }
+
+        /// <summary>
+        /// Tests that OnNewLoginTokenReceived event handlers are called in the order they were subscribed.
+        /// </summary>
+        [Test]
+        public void OnNewLoginTokenReceived_MultipleHandlers_ExecuteInOrder()
+        {
+            void Handler1(LoginTokenInfoResult result) => eventLog.Add("1");
+            void Handler2(LoginTokenInfoResult result) => eventLog.Add("2");
+            void Handler3(LoginTokenInfoResult result) => eventLog.Add("3");
+
+            userSystem.OnNewLoginTokenReceived += Handler1;
+            userSystem.OnNewLoginTokenReceived += Handler2;
+            userSystem.OnNewLoginTokenReceived += Handler3;
+
+            var tokenResult = System.Runtime.Serialization.FormatterServices.GetUninitializedObject(typeof(LoginTokenInfoResult)) as LoginTokenInfoResult;
+            FireLoginTokenEvent(tokenResult);
+            
+            Assert.AreEqual(3, eventLog.Count, "All handlers should have been called.");
+            Assert.AreEqual("1", eventLog[0], "Handler1 should execute first.");
+            Assert.AreEqual("2", eventLog[1], "Handler2 should execute second.");
+            Assert.AreEqual("3", eventLog[2], "Handler3 should execute third.");
+        }
+
+        /// <summary>
+        /// Tests that OnNewLoginTokenReceived event handler receives correct sender parameter.
+        /// Note: some event signatures don't include a sender parameter; this test verifies the handler receives the event parameter.
+        /// </summary>
+        [Test]
+        public void OnNewLoginTokenReceived_Handler_ReceivesParameter()
+        {
+            LoginTokenInfoResult receivedParam = null;
+
+            void TokenReceivedHandler(LoginTokenInfoResult result)
+            {
+                receivedParam = result;
+            }
+            
+            // Subscribe to the real event
+            userSystem.OnNewLoginTokenReceived += TokenReceivedHandler;
+
+            var tokenResult = System.Runtime.Serialization.FormatterServices.GetUninitializedObject(typeof(LoginTokenInfoResult)) as LoginTokenInfoResult;
+            FireLoginTokenEvent(tokenResult);
+            
+            Assert.IsNotNull(receivedParam, "Parameter should be passed to handler.");
+        }
+
+        /// <summary>
+        /// Tests that handlers can be unsubscribed from OnNewLoginTokenReceived event and won't be called.
+        /// </summary>
+        [Test]
+        public void OnNewLoginTokenReceived_Unsubscribe_HandlerNotCalled()
+        {
+            var handlerCalled = false;
+            void TokenReceivedHandler(LoginTokenInfoResult result)
+            {
+                handlerCalled = true;
+                eventLog.Add("Handler called");
+            }
+            
+            // Subscribe, then unsubscribe
+            userSystem.OnNewLoginTokenReceived += TokenReceivedHandler;
+            userSystem.OnNewLoginTokenReceived -= TokenReceivedHandler;
+
+            var tokenResult = System.Runtime.Serialization.FormatterServices.GetUninitializedObject(typeof(LoginTokenInfoResult)) as LoginTokenInfoResult;
+            FireLoginTokenEvent(tokenResult);
+            
+            Assert.IsFalse(handlerCalled, "Unsubscribed handler should not be called.");
+            Assert.IsFalse(eventLog.Contains("Handler called"), "Event log should not contain handler call.");
+        }
+
+        /// <summary>
+        /// Tests that OnNewLoginTokenReceived event is not fired when no handlers are subscribed.
+        /// </summary>
+        [Test]
+        public void OnNewLoginTokenReceived_NoHandlers_NoErrorsOnFire()
+        {
+            // Fire event with no handlers (should not throw)
+            var tokenResult = System.Runtime.Serialization.FormatterServices.GetUninitializedObject(typeof(LoginTokenInfoResult)) as LoginTokenInfoResult;
+            
+            Assert.DoesNotThrow(() => FireLoginTokenEvent(tokenResult), 
+                "Firing event with no handlers should not throw an exception.");
+            Assert.AreEqual(0, eventLog.Count, "No handlers should have been called.");
+        }
+
+        /// <summary>
+        /// Tests that OnNewLoginTokenReceived event handler properly receives and processes token data.
+        /// </summary>
+        [Test]
+        public void OnNewLoginTokenReceived_Handler_ProcessesTokenDataCorrectly()
+        {
+            var processedTokens = new List<object>();
+            var processedExpirations = new List<object>();
+
+            void TokenProcessor(LoginTokenInfoResult result)
+            {
+                if (result != null)
+                {
+                    processedTokens.Add(result);
+                    processedExpirations.Add(result);
+                }
+            }
+            
+            userSystem.OnNewLoginTokenReceived += TokenProcessor;
+
+            // Fire multiple token events
+            var token1 = System.Runtime.Serialization.FormatterServices.GetUninitializedObject(typeof(LoginTokenInfoResult)) as LoginTokenInfoResult;
+            var token2 = System.Runtime.Serialization.FormatterServices.GetUninitializedObject(typeof(LoginTokenInfoResult)) as LoginTokenInfoResult;
+
+            FireLoginTokenEvent(token1);
+            FireLoginTokenEvent(token2);
+
+            Assert.AreEqual(2, processedTokens.Count, "Both tokens should be processed.");
+            Assert.AreEqual(2, processedExpirations.Count, "Both expirations should be processed.");
+        }
+
+        /// <summary>
+        /// Tests that the event subscriptions are properly isolated between different test instances.
+        /// </summary>
+        [Test]
+        public void Events_IsolationBetweenTests_NoContamination()
+        {
+            var testEventFired = false;
+
+            void TestHandler(LoginTokenInfoResult result)
+            {
+                testEventFired = true;
+            }
+            
+            userSystem.OnNewLoginTokenReceived += TestHandler;
+
+            Assert.IsFalse(testEventFired, "Event should not be fired yet.");
+            
+            var tokenResult = System.Runtime.Serialization.FormatterServices.GetUninitializedObject(typeof(LoginTokenInfoResult)) as LoginTokenInfoResult;
+            FireLoginTokenEvent(tokenResult);
+            
+            Assert.IsTrue(testEventFired, "Event should have been fired.");
+        }
+#endif
+    }
+}
+

--- a/UnityProject/CspUnityTests/Assets/Scripts/IntegrationTests/EventTests.cs.meta
+++ b/UnityProject/CspUnityTests/Assets/Scripts/IntegrationTests/EventTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 626af778fe5c466bb33f48ddb677309b
+timeCreated: 1772031944

--- a/UnityProject/CspUnityTests/Assets/Scripts/IntegrationTests/Spaces/SpacesTests.cs
+++ b/UnityProject/CspUnityTests/Assets/Scripts/IntegrationTests/Spaces/SpacesTests.cs
@@ -68,7 +68,7 @@ namespace IntegrationTests.Spaces
                     null, new StringArray(tags)));
             Assert.AreEqual((ushort)HttpStatusCode.OK, generatedNotOwnedSpaceResult.ReturnCode);
             Assert.IsNotNull(generatedNotOwnedSpaceResult.ReturnData);
-            return generatedNotOwnedSpaceResult.ReturnData.GetSpace();
+            return generatedNotOwnedSpaceResult.ReturnData.GetSpace().DeepCopy();
         }
         #endregion
     }

--- a/UnityProject/CspUnityTests/Assets/Scripts/Runtime/User/UserApi.cs
+++ b/UnityProject/CspUnityTests/Assets/Scripts/Runtime/User/UserApi.cs
@@ -57,7 +57,7 @@ namespace Magnopus.Foundation.Unity.Runtime.User
             userSystem = null;
         }
 
-        private void OnNewLoginTokenReceived(object sender, FoundationSystems.LoginTokenInfoResult loginTokenAccessor)
+        private void OnNewLoginTokenReceived(FoundationSystems.LoginTokenInfoResult loginTokenAccessor)
         {
             if (loginTokenAccessor != null)
             {
@@ -83,7 +83,7 @@ namespace Magnopus.Foundation.Unity.Runtime.User
             throw new CspResultEndpointException($"Login token was called but found null result.", HttpStatusCode.NotFound);
         }
 
-        private void OnUserPermissionsChangedCallback(object sender, FoundationCommon.AccessControlChangedNetworkEventData message)
+        private void OnUserPermissionsChangedCallback(FoundationCommon.AccessControlChangedNetworkEventData message)
         {
             if (message == null)
             {

--- a/UnityProject/CspUnityTests/Assets/Scripts/Runtime/User/UserApi.cs
+++ b/UnityProject/CspUnityTests/Assets/Scripts/Runtime/User/UserApi.cs
@@ -40,18 +40,16 @@ namespace Magnopus.Foundation.Unity.Runtime.User
             this.userSystem = userSystem ?? throw new CspResultException("Could not get user service");
             this.externalServiceProxySystem = externalServiceProxySystem ?? throw new CspResultException("Could not get external service proxy system");
 
-            // TODO: Uncomment when events are available through SWIG
-            //this.userSystem.OnNewLoginTokenReceived += OnNewLoginTokenReceived;
-            //this.userSystem.OnUserPermissionsChanged += OnUserPermissionsChangedCallback;
+            this.userSystem.OnNewLoginTokenReceived += OnNewLoginTokenReceived;
+            this.userSystem.OnUserPermissionsChanged += OnUserPermissionsChangedCallback;
         }
 
         public void Dispose()
         {
             if (userSystem != null)
             {
-                // TODO: Uncomment when events are available through SWIG
-                //userSystem.OnNewLoginTokenReceived -= OnNewLoginTokenReceived;
-                //userSystem.OnUserPermissionsChanged -= OnUserPermissionsChangedCallback;
+                userSystem.OnNewLoginTokenReceived -= OnNewLoginTokenReceived;
+                userSystem.OnUserPermissionsChanged -= OnUserPermissionsChangedCallback;
             }
 
             userSystem = null;

--- a/UnityProject/CspUnityTests/Assets/Scripts/Runtime/User/UserApi.cs
+++ b/UnityProject/CspUnityTests/Assets/Scripts/Runtime/User/UserApi.cs
@@ -455,7 +455,7 @@ namespace Magnopus.Foundation.Unity.Runtime.User
                 var responseBody = result.GetResponseBody();
                 Debug.Log($"Profile result response body: {responseBody}");
 
-                FoundationSystems.Profile profile = result.GetProfile();
+                FoundationSystems.Profile profile = result.GetProfile().DeepCopy();
                 if (profile == null)
                 {
                     throw new CspResultEndpointException("Did not create account, endpoint result was null.",
@@ -532,7 +532,7 @@ namespace Magnopus.Foundation.Unity.Runtime.User
 
                 Debug.Log($"Reading profile from request response ...");
 
-                FoundationSystems.Profile profile = result.GetProfile();
+                FoundationSystems.Profile profile = result.GetProfile().DeepCopy();
 
                 Debug.Log($"Checking profile from request response ...");
 
@@ -635,7 +635,7 @@ namespace Magnopus.Foundation.Unity.Runtime.User
                 FoundationSystems.ProfileResult result =
                     await userSystem.UpgradeGuestAccountAsync(userName, displayName, email, password);
 
-                FoundationSystems.Profile profile = result.GetProfile();
+                FoundationSystems.Profile profile = result.GetProfile().DeepCopy();
                 if (profile == null)
                 {
                     throw new CspResultEndpointException("Did not upgrade guest account, endpoint result was null.",

--- a/interface/CSP/Systems/Spaces/Space.i
+++ b/interface/CSP/Systems/Spaces/Space.i
@@ -7,3 +7,7 @@ ADD_OUTER_OBJECT_PIN_SLOT(csp::systems::BasicSpace)
 ADD_OUTER_OBJECT_PIN_SLOT(csp::systems::SpaceGeoLocation)
 
 %include "CSP/Systems/Spaces/Space.h"
+
+// ---------------------------------------------------------
+
+CSP_DEEP_COPY(csp::systems::Space)

--- a/interface/CSP/Systems/Users/Profile.i
+++ b/interface/CSP/Systems/Users/Profile.i
@@ -7,3 +7,7 @@ ADD_OUTER_OBJECT_PIN_SLOT(csp::systems::Profile)
 ADD_OUTER_OBJECT_PIN_SLOT(csp::systems::ProfileResult)
 
 %include "CSP/Systems/Users/Profile.h"
+
+// ---------------------------------------------------------
+
+CSP_DEEP_COPY(csp::systems::Profile)

--- a/interface/CSP/Systems/Users/UserSystem.i
+++ b/interface/CSP/Systems/Users/UserSystem.i
@@ -5,3 +5,20 @@
 ADD_OUTER_OBJECT_PIN_SLOT(csp::systems::UserSystem)
 
 %include "CSP/Systems/Users/UserSystem.h"
+
+%extend csp::systems::UserSystem {
+
+    MAKE_EVENT_FOR_CALLBACK(
+        OnNewLoginTokenReceived,
+        ConnectedSpacesPlatformDotNet.LoginTokenInfoCallback,
+        SetNewLoginTokenReceivedCallback,
+        csp.systems.LoginTokenInfoResult
+    )
+
+    MAKE_EVENT_FOR_CALLBACK(
+        OnUserPermissionsChanged,
+        ConnectedSpacesPlatformDotNet.UserPermissionsChangedCallback,
+        SetUserPermissionsChangedCallback,
+        csp.common.AccessControlChangedNetworkEventData
+    )
+}

--- a/interface/main.i
+++ b/interface/main.i
@@ -22,6 +22,7 @@
 %include "swigutils/typemaps/Csp_List.i"
 %include "swigutils/typemaps/Csp_Array.i"
 %include "swigutils/typemaps/Csp_Optional.i"
+%include "swigutils/typemaps/Csp_DeepCopy.i"
 
 /* Optionals need a bit of config, as we need to setup the project to allow C# nullability */
 #define SWIG_STD_OPTIONAL_USE_NULLABLE_REFERENCE_TYPES // Allow optional reference types (>C#8.0)

--- a/interface/main.i
+++ b/interface/main.i
@@ -30,6 +30,7 @@
 %include "Declarations/AsyncDeclarations.i"
 
 %include "swigutils/OuterObjectPins.i"
+%include "swigutils/Events.i"
 %include "swigutils/Exceptions.i"
 %include "swigutils/Operators.i"
 %include "swigutils/Equatable.i"

--- a/interface/swigutils/Events.i
+++ b/interface/swigutils/Events.i
@@ -1,0 +1,192 @@
+/*
+ * MAKE_EVENT_FOR_CALLBACK
+ * ----------------------
+ *
+ * Generates a managed C# event that is backed by a native CSP-style callback.
+ *
+ * This macro bridges native callbacks into idiomatic C# event semantics, allowing
+ * C# clients to subscribe and unsubscribe using standard += / -= syntax without
+ * writing any callback plumbing themselves.
+ *
+ * Key features:
+ * -------------
+ * - Multicast event support (multiple subscribers)
+ * - Lazy native callback registration (on first subscription)
+ * - Automatic native callback unregistration (on last unsubscription)
+ * - Correct lifetime management of native callback adapters
+ * - No additional user-side boilerplate required
+ *
+ * The macro emits managed C# code into the SWIG-generated proxy class using
+ * %proxycode. It relies on an action-based callback adapter created via
+ * MAKE_ACTION_CALLBACK.
+ *
+ * This macro is suitable for exposing "SetXCallback(...)" style APIs as C# events.
+ *
+ *
+ * Assumptions / Requirements:
+ * ---------------------------
+ *
+ * 1. A native setter function exists with the following form:
+ *
+ *      void SetXCallback(CallbackType callback);
+ *
+ *    This setter must accept a callback adapter (or nullptr / null to unregister).
+ *
+ * 2. A managed action callback adapter has already been defined using
+ *    MAKE_ACTION_CALLBACK. That adapter must:
+ *
+ *    - Inherit from the director callback base type
+ *    - Accept a System.Action<PAYLOAD_TYPE> in its constructor
+ *    - Forward native callback invocations to the managed Action
+ *
+ *
+ * Generated C# Members:
+ * ---------------------
+ *
+ * The macro generates the following members inside the proxy class:
+ *
+ *   private ACTION_CALLBACK_TYPENAME _<EVENT_NAME>Adapter;
+ *   private Action<PAYLOAD_TYPE> _<EVENT_NAME>;
+ *   private int _<EVENT_NAME>SubscriberCount;
+ *
+ *   public event Action<PAYLOAD_TYPE> EVENT_NAME;
+ *
+ *   private void Register<EVENT_NAME>Callback();
+ *   private void Unregister<EVENT_NAME>Callback();
+ *   private void On<EVENT_NAME>Native(PAYLOAD_TYPE args);
+ *
+ *
+ * Event semantics:
+ * ----------------
+ *
+ * - Native callback registration occurs when the first subscriber is added.
+ * - Native callback unregistration occurs when the last subscriber is removed.
+ * - The callback adapter is strongly rooted for the duration of the subscription.
+ * - The event supports multicast delegates.
+ *
+ * Threading semantics are identical to the underlying native callback. If main-thread
+ * dispatch (e.g. Unity) is required, it must be layered on top of this mechanism.
+ *
+ *
+ * Parameters:
+ * -----------
+ *
+ * EVENT_NAME
+ *   - The public name of the C# event to be generated.
+ *   - Used to derive managed helper method names (Register*, On*Native, etc.).
+ *   - Example: OnNewLoginTokenReceived
+ *
+ * ACTION_CALLBACK_TYPENAME
+ *  - The fully-qualified managed type name of an action callback adapter
+ *    generated via MAKE_ACTION_CALLBACK.
+ *  - This type must include the SWIG module namespace.
+ *  - Example:
+ *      ConnectedSpacesPlatformDotNet.LoginTokenInfoResultActionCallback
+ *
+ * NATIVE_SETTER
+ *   - The exact name of the native setter function used to register and unregister
+ *     the callback.
+ *   - This function is called with:
+ *       - An adapter instance when registering
+ *       - null when unregistering
+ *   - Example: SetNewLoginTokenReceivedCallback
+ *
+ * PAYLOAD_TYPE
+ *   - The managed payload type exposed to event subscribers.
+ *   - May be a single type or a comma-separated list of types for multi-parameter
+ *     callbacks.
+ *   - Must match the signature expected by ACTION_CALLBACK_TYPENAME.
+ *
+ *
+ * Usage Example:
+ * --------------
+ *
+ *   // Define the action callback adapter (once per signature)
+ *   MAKE_ACTION_CALLBACK(
+ *       LoginTokenInfoCallback,
+ *       LoginTokenInfoResultCallbackAdapter,
+ *       LoginTokenInfoResult value,
+ *       LoginTokenInfoResult,
+ *       value
+ *   )
+ *
+ *   // Expose the native callback as a C# event
+ *   MAKE_EVENT_FOR_CALLBACK(
+ *       OnNewLoginTokenReceived,
+ *       ConnectedSpacesPlatformDotNet.LoginTokenInfoCallback,
+ *       SetNewLoginTokenReceivedCallback,
+ *       LoginTokenInfoResult
+ *   )
+ *
+ *
+ * Resulting C# usage:
+ * -------------------
+ *
+ *   instance.OnNewLoginTokenReceived += result =>
+ *   {
+ *       // Handle event
+ *   };
+ *
+ *   instance.OnNewLoginTokenReceived -= handler;
+ *
+ *
+ * Notes:
+ * ------
+ * - Native callback registration is reference-counted per event.
+ * - Removing a handler that was never added is safely ignored.
+ * - Callback adapter lifetime is fully managed by the generated proxy.
+ * - Async/await wrappers can be layered on top of the same callback adapters.
+ */
+%define MAKE_EVENT_FOR_CALLBACK(EVENT_NAME, ACTION_CALLBACK_TYPENAME, NATIVE_SETTER, PAYLOAD_TYPE)
+%proxycode %{
+    private ACTION_CALLBACK_TYPENAME? _##EVENT_NAME##Adapter;
+    private System.Action<object, PAYLOAD_TYPE>? _##EVENT_NAME;
+    private int _##EVENT_NAME##SubscriberCount;
+
+    public event System.Action<object, PAYLOAD_TYPE> EVENT_NAME
+    {
+        add
+        {
+            _##EVENT_NAME += value;
+
+            if (++_##EVENT_NAME##SubscriberCount == 1)
+                Register##EVENT_NAME##Callback();
+        }
+        remove
+        {
+            _##EVENT_NAME -= value;
+
+            if (_##EVENT_NAME##SubscriberCount <= 0)
+                return;
+
+            if (--_##EVENT_NAME##SubscriberCount == 0)
+                Unregister##EVENT_NAME##Callback();
+        }
+    }
+
+    private void Register##EVENT_NAME##Callback()
+    {
+        _##EVENT_NAME##Adapter =
+            new ACTION_CALLBACK_TYPENAME(On##EVENT_NAME##Native);
+
+        NATIVE_SETTER(_##EVENT_NAME##Adapter);
+    }
+
+    private void Unregister##EVENT_NAME##Callback()
+    {
+        // Stop managed dispatch first
+        _##EVENT_NAME = null;
+
+        // Unregister native callback
+        NATIVE_SETTER(null);
+
+        // Release adapter
+        _##EVENT_NAME##Adapter = null;
+    }
+
+    private void On##EVENT_NAME##Native(PAYLOAD_TYPE args)
+        => _##EVENT_NAME?.Invoke(this, args);
+%}
+
+%enddef
+

--- a/interface/swigutils/Events.i
+++ b/interface/swigutils/Events.i
@@ -1,192 +1,192 @@
 /*
- * MAKE_EVENT_FOR_CALLBACK
- * ----------------------
+ * Support for exposing native C++ callback-style APIs as idiomatic C# events.
  *
- * Generates a managed C# event that is backed by a native CSP-style callback.
+ * This file defines MAKE_EVENT_FOR_CALLBACK, which maps a native
+ * "SetXCallback(CallbackType)" API to a managed C# event.
  *
- * This macro bridges native callbacks into idiomatic C# event semantics, allowing
- * C# clients to subscribe and unsubscribe using standard += / -= syntax without
- * writing any callback plumbing themselves.
+ * ----------------------------------------------------------------------
+ * WHAT THIS MACRO REPRESENTS
+ * ----------------------------------------------------------------------
  *
- * Key features:
- * -------------
- * - Multicast event support (multiple subscribers)
- * - Lazy native callback registration (on first subscription)
- * - Automatic native callback unregistration (on last unsubscription)
- * - Correct lifetime management of native callback adapters
- * - No additional user-side boilerplate required
+ * This macro is ONLY for long-lived, multi-fire notifications.
  *
- * The macro emits managed C# code into the SWIG-generated proxy class using
- * %proxycode. It relies on an action-based callback adapter created via
- * MAKE_ACTION_CALLBACK.
+ * Use it when the native API represents:
+ *   - A signal or notification
+ *   - That may fire zero or more times
+ *   - That has no completion concept
  *
- * This macro is suitable for exposing "SetXCallback(...)" style APIs as C# events.
+ * Examples:
+ *   - State changes
+ *   - Presence updates
+ *   - Entity added / removed
  *
+ * If the API represents a request/response or something that should be
+ * awaited, DO NOT use this macro.
  *
- * Assumptions / Requirements:
- * ---------------------------
+ * ----------------------------------------------------------------------
+ * RELATIONSHIP TO OTHER ABSTRACTIONS
+ * ----------------------------------------------------------------------
  *
- * 1. A native setter function exists with the following form:
+ * Callbacks:
+ *   - Low-level transport mechanism (native → managed)
+ *   - Implemented via SWIG directors and MAKE_ACTION_CALLBACK
+ *   - Not user-facing
+ *
+ * Async APIs:
+ *   - Single-shot operations
+ *   - Exposed as Task<T>
+ *   - Own and dispose their callback on completion
+ *
+ * Events (this macro):
+ *   - Long-lived
+ *   - Multicast
+ *   - Not awaited
+ *   - Owned by the publisher
+ *
+ * These abstractions have different lifetime and ownership rules and
+ * intentionally use different macros.
+ *
+ * ----------------------------------------------------------------------
+ * REQUIREMENTS
+ * ----------------------------------------------------------------------
+ *
+ * 1. Native API must expose:
  *
  *      void SetXCallback(CallbackType callback);
  *
- *    This setter must accept a callback adapter (or nullptr / null to unregister).
+ *    Passing null must unregister the callback.
  *
- * 2. A managed action callback adapter has already been defined using
- *    MAKE_ACTION_CALLBACK. That adapter must:
+ * 2. A managed callback adapter must already exist via MAKE_ACTION_CALLBACK.
  *
- *    - Inherit from the director callback base type
- *    - Accept a System.Action<PAYLOAD_TYPE> in its constructor
- *    - Forward native callback invocations to the managed Action
+ * 3. AsyncLifetime.Root / Unroot must be available for GC safety.
  *
+ * ----------------------------------------------------------------------
+ * LIFETIME MODEL
+ * ----------------------------------------------------------------------
  *
- * Generated C# Members:
- * ---------------------
+ * - One native callback adapter per event
+ * - Adapter is created on first subscription
+ * - Adapter is explicitly rooted while at least one subscriber exists
+ * - Adapter is unregistered and unrooted when the last subscriber is removed
  *
- * The macro generates the following members inside the proxy class:
+ * This prevents:
+ *   - GC collecting adapters still referenced by native code
+ *   - Duplicate native registrations
+ *   - Callback leaks
  *
- *   private ACTION_CALLBACK_TYPENAME _<EVENT_NAME>Adapter;
- *   private Action<PAYLOAD_TYPE> _<EVENT_NAME>;
- *   private int _<EVENT_NAME>SubscriberCount;
+ * ----------------------------------------------------------------------
+ * CONSUMER USAGE (C#)
+ * ----------------------------------------------------------------------
  *
- *   public event Action<PAYLOAD_TYPE> EVENT_NAME;
+ * Events exposed by this macro are consumed idiomatically:
  *
- *   private void Register<EVENT_NAME>Callback();
- *   private void Unregister<EVENT_NAME>Callback();
- *   private void On<EVENT_NAME>Native(PAYLOAD_TYPE args);
+ *     instance.OnSomethingHappened += payload =>
+ *     {
+ *         // Handle event
+ *     };
  *
+ *     instance.OnSomethingHappened -= handler;
  *
- * Event semantics:
- * ----------------
+ * Consumers do NOT:
+ *   - Manage callbacks
+ *   - Root adapters
+ *   - Call native setters
  *
- * - Native callback registration occurs when the first subscriber is added.
- * - Native callback unregistration occurs when the last subscriber is removed.
- * - The callback adapter is strongly rooted for the duration of the subscription.
- * - The event supports multicast delegates.
+ * The binding layer owns all lifecycle concerns.
  *
- * Threading semantics are identical to the underlying native callback. If main-thread
- * dispatch (e.g. Unity) is required, it must be layered on top of this mechanism.
+ * ----------------------------------------------------------------------
+ * THREADING
+ * ----------------------------------------------------------------------
  *
- *
- * Parameters:
- * -----------
- *
- * EVENT_NAME
- *   - The public name of the C# event to be generated.
- *   - Used to derive managed helper method names (Register*, On*Native, etc.).
- *   - Example: OnNewLoginTokenReceived
- *
- * ACTION_CALLBACK_TYPENAME
- *  - The fully-qualified managed type name of an action callback adapter
- *    generated via MAKE_ACTION_CALLBACK.
- *  - This type must include the SWIG module namespace.
- *  - Example:
- *      ConnectedSpacesPlatformDotNet.LoginTokenInfoResultActionCallback
- *
- * NATIVE_SETTER
- *   - The exact name of the native setter function used to register and unregister
- *     the callback.
- *   - This function is called with:
- *       - An adapter instance when registering
- *       - null when unregistering
- *   - Example: SetNewLoginTokenReceivedCallback
- *
- * PAYLOAD_TYPE
- *   - The managed payload type exposed to event subscribers.
- *   - May be a single type or a comma-separated list of types for multi-parameter
- *     callbacks.
- *   - Must match the signature expected by ACTION_CALLBACK_TYPENAME.
- *
- *
- * Usage Example:
- * --------------
- *
- *   // Define the action callback adapter (once per signature)
- *   MAKE_ACTION_CALLBACK(
- *       LoginTokenInfoCallback,
- *       LoginTokenInfoResultCallbackAdapter,
- *       LoginTokenInfoResult value,
- *       LoginTokenInfoResult,
- *       value
- *   )
- *
- *   // Expose the native callback as a C# event
- *   MAKE_EVENT_FOR_CALLBACK(
- *       OnNewLoginTokenReceived,
- *       ConnectedSpacesPlatformDotNet.LoginTokenInfoCallback,
- *       SetNewLoginTokenReceivedCallback,
- *       LoginTokenInfoResult
- *   )
- *
- *
- * Resulting C# usage:
- * -------------------
- *
- *   instance.OnNewLoginTokenReceived += result =>
- *   {
- *       // Handle event
- *   };
- *
- *   instance.OnNewLoginTokenReceived -= handler;
- *
- *
- * Notes:
- * ------
- * - Native callback registration is reference-counted per event.
- * - Removing a handler that was never added is safely ignored.
- * - Callback adapter lifetime is fully managed by the generated proxy.
- * - Async/await wrappers can be layered on top of the same callback adapters.
+ * Event handlers execute on the same thread as the native callback.
+ * This macro does not impose any thread marshalling.
  */
-%define MAKE_EVENT_FOR_CALLBACK(EVENT_NAME, ACTION_CALLBACK_TYPENAME, NATIVE_SETTER, PAYLOAD_TYPE)
-%proxycode %{
-    private ACTION_CALLBACK_TYPENAME? _##EVENT_NAME##Adapter;
-    private System.Action<object, PAYLOAD_TYPE>? _##EVENT_NAME;
-    private int _##EVENT_NAME##SubscriberCount;
 
-    public event System.Action<object, PAYLOAD_TYPE> EVENT_NAME
+%define MAKE_EVENT_FOR_CALLBACK(
+    EVENT_NAME,
+    ACTION_CALLBACK_TYPENAME,
+    NATIVE_SETTER,
+    PAYLOAD_TYPE
+)
+%proxycode %{
+
+    // Native callback adapter instance (one per event)
+    private ACTION_CALLBACK_TYPENAME? _##EVENT_NAME##Adapter;
+
+    // Backing multicast delegate for the managed event
+    private event System.Action<PAYLOAD_TYPE>? _##EVENT_NAME;
+
+    /*
+     * Public managed event.
+     *
+     * Native callback registration occurs on first subscription.
+     * Native callback unregistration occurs when the last subscriber is removed.
+     */
+    public event System.Action<PAYLOAD_TYPE> EVENT_NAME
     {
         add
         {
-            _##EVENT_NAME += value;
-
-            if (++_##EVENT_NAME##SubscriberCount == 1)
+            // First subscriber: register native callback
+            if (_##EVENT_NAME == null)
                 Register##EVENT_NAME##Callback();
+
+            _##EVENT_NAME += value;
         }
         remove
         {
             _##EVENT_NAME -= value;
 
-            if (_##EVENT_NAME##SubscriberCount <= 0)
-                return;
-
-            if (--_##EVENT_NAME##SubscriberCount == 0)
+            // Last subscriber removed: unregister native callback
+            if (_##EVENT_NAME == null)
                 Unregister##EVENT_NAME##Callback();
         }
     }
 
+    /*
+     * Registers the native callback and roots the adapter.
+     * This method is idempotent and safe to call multiple times.
+     */
     private void Register##EVENT_NAME##Callback()
     {
+        if (_##EVENT_NAME##Adapter != null)
+            return;
+
         _##EVENT_NAME##Adapter =
             new ACTION_CALLBACK_TYPENAME(On##EVENT_NAME##Native);
 
+        // Root the adapter to prevent GC while native code holds it
+        ConnectedSpacesPlatformDotNet.AsyncLifetime.Root(_##EVENT_NAME##Adapter);
+
+        // Register native callback
         NATIVE_SETTER(_##EVENT_NAME##Adapter);
     }
 
+    /*
+     * Unregisters the native callback and releases the adapter.
+     * This method is idempotent and safe to call multiple times.
+     */
     private void Unregister##EVENT_NAME##Callback()
     {
-        // Stop managed dispatch first
-        _##EVENT_NAME = null;
+        if (_##EVENT_NAME##Adapter == null)
+            return;
 
-        // Unregister native callback
+        // Unregister native callback FIRST to avoid race conditions
         NATIVE_SETTER(null);
 
-        // Release adapter
+        // Stop managed dispatch
+        _##EVENT_NAME = null;
+
+        // Unroot adapter and release reference
+        ConnectedSpacesPlatformDotNet.AsyncLifetime.Unroot(_##EVENT_NAME##Adapter);
         _##EVENT_NAME##Adapter = null;
     }
 
+    /*
+     * Entry point invoked by native code via the callback adapter.
+     * Forwards the payload to managed subscribers.
+     */
     private void On##EVENT_NAME##Native(PAYLOAD_TYPE args)
-        => _##EVENT_NAME?.Invoke(this, args);
+        => _##EVENT_NAME?.Invoke(args);
+
 %}
-
 %enddef
-

--- a/interface/swigutils/typemaps/CSP_DeepCopy.i
+++ b/interface/swigutils/typemaps/CSP_DeepCopy.i
@@ -1,0 +1,19 @@
+// Macro to add DeepCopy for any class
+%define CSP_DEEP_COPY(CLASS)
+    // C++ side: add a copy constructor wrapper
+    %extend CLASS {
+        CLASS* DeepCopy() {
+            return new CLASS(*$self);
+        }
+    }
+
+    // C# side: auto-generate DeepCopy() method that owns the copy
+    %typemap(csclassmod) CLASS "
+    public partial class $csclassname {
+        public $csclassname DeepCopy() {
+            global::System.IntPtr cPtr = ConnectedSpacesPlatformDotNetPINVOKE.$csclassname_DeepCopy(swigCPtr);
+            return (cPtr == global::System.IntPtr.Zero) ? null : new $csclassname(cPtr, true);
+        }
+    }
+    "
+%enddef


### PR DESCRIPTION
[FOR CONSIDERATION]

This could be merged after the following PRs:
- https://github.com/magnopus-opensource/connected-spaces-platform-unity/pull/48
- https://github.com/magnopus-opensource/connected-spaces-platform-unity/pull/49

The idea around this PR is to introduce a macro that allows us to expose a "DeepCopy()" function injected into arbitrary classes via swig, which can be used to force the use of the copy constructor for copiable objects.

Update: I am debating if we should introduce already this macro or not. It is a nice to have for devs, but I cannot identify a specific scenario yet where we would want to use the DeepCopy since we already introduced before this the pinning for the outer objects [in the previous PR](https://github.com/magnopus-opensource/connected-spaces-platform-unity/pull/47), which resolves memory issues caused by GC.

Until we decide if we might want this, I am keeping this PR as a draft.