### PR TITLE
[OPE-3118] Update cmake to install CSP only when shared libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,18 +55,6 @@ if(ENABLE_THROW_EXCEPTION_ON_RESULTBASE_FAILURE)
     set(THROW_EXCEPTION_ON_RESULTBASE_FAILURE_FLAG "-DTHROW_EXCEPTION_ON_RESULTBASE_FAILURE=1")
 endif()
 
-# Decide SWIG dllimport name per platform.
-set(SWIG_DLLIMPORT_NAME "${_WRAPPER_MODULE_NAME}")
-
-if(CMAKE_SYSTEM_NAME STREQUAL "iOS" OR CMAKE_SYSTEM_NAME STREQUAL "visionOS")
-    # Note: on iOS and visionOS we need __Internal on the DllImport of the PInvoke, or it won't find the symbols.
-    # This is because on iOS, the code gets statically linked into the final executable, and __Internal tells the 
-    # runtime to look for symbols in the main executable binary itself, rather than looking for a separate dynamic library.
-    # More info on the issue here: https://gitlab.com/rdi-eg/docs/-/wikis/Targeting-iOS-on-Unity3D-using-C%23-swig-generated-code---pitfalls-and-gotchas/diff?version_id=130894855efdab4f0cbd9882e7dc35554fea92bd&view=inline
-    message(STATUS "Configuring SWIG for iOS / visionOS (__Internal)")
-    set(SWIG_DLLIMPORT_NAME "__Internal")
-endif()
-
 # Setup SWIG invocation
 add_custom_command(
   OUTPUT "${_CPP_WRAPPER_OUT}"
@@ -100,6 +88,7 @@ if (BUILD_SHARED_LIBS)
 else()
   add_library(${_WRAPPER_MODULE_NAME} STATIC "${_CPP_WRAPPER_OUT}")
 endif()
+
 set_target_properties(${_WRAPPER_MODULE_NAME} PROPERTIES
   CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
@@ -110,10 +99,11 @@ set_target_properties(${_WRAPPER_MODULE_NAME} PROPERTIES
 # Add CSP Target to our output library, this produces a final API that can use CSP.
 target_link_libraries(${_WRAPPER_MODULE_NAME} PRIVATE _CSP)
 
+# iOS / visionOS static-force-load
 if(CMAKE_SYSTEM_NAME STREQUAL "iOS" OR CMAKE_SYSTEM_NAME STREQUAL "visionOS")
-    # Additionally, on iOS and visionOS we have to force load the CSP static library because the dynamic lookup doesn't 
-    # work with static libraries, and we don't have a choice but to use static libs on iOS.
-    target_link_options(${_WRAPPER_MODULE_NAME} PRIVATE "-Wl,-force_load,$<TARGET_FILE:_CSP>")
+  target_link_options(${_WRAPPER_MODULE_NAME}
+    PRIVATE "-Wl,-force_load,$<TARGET_FILE:_CSP>"
+  )
 endif()
 
 # Force /MD (Release runtime) to match CSP DLL runtime library settings
@@ -126,23 +116,26 @@ if(MSVC)
   )
 endif()
 
+# macOS rpath
 # Ensure the wrapper can resolve @rpath by looking in its own folder at runtime.
 # This makes the dependent lookup land on the sibling dylib.
 set_target_properties(${_WRAPPER_MODULE_NAME} PROPERTIES
-    MACOSX_RPATH ON
-    INSTALL_RPATH "@loader_path"
-    BUILD_RPATH   "@loader_path"
-    BUILD_WITH_INSTALL_RPATH TRUE
+  MACOSX_RPATH ON
+  INSTALL_RPATH "@loader_path"
+  BUILD_RPATH "@loader_path"
 )
 
+# iOS signing disabled
 # When building for ios, it will complain, but we don't need to sign (I think...) because we're just a static library
 # (Dynamic would need to be signed ... is this why we don't support dynamic on ios?)
 set_target_properties(${_WRAPPER_MODULE_NAME} PROPERTIES
-    XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "NO"
-    XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO"
-    XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
+  XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "NO"
+  XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO"
 )
 
+# Diagnostics
+get_target_property(_CSP_TYPE _CSP TYPE)
+message(STATUS "CSP target type: ${_CSP_TYPE}")
 
 include(cmake/PackageInstall.cmake)
 

--- a/cmake/PackageInstall.cmake
+++ b/cmake/PackageInstall.cmake
@@ -24,7 +24,15 @@ if(MSVC)
   install(
     FILES $<TARGET_PDB_FILE:${_WRAPPER_MODULE_NAME}>
     DESTINATION "${INSTALL_DIR}/bin"
+    CONFIGURATIONS Debug
+    OPTIONAL
+  )
+elseif(APPLE)
+  install(
+    DIRECTORY "$<TARGET_FILE:${_WRAPPER_MODULE_NAME}>.dSYM"
+    DESTINATION "${INSTALL_DIR}/bin"
     CONFIGURATIONS Debug RelWithDebInfo #RelWithDebInfo doesn't exist, but it'll want to be here when it does.
+    OPTIONAL
   )
 endif()
 
@@ -48,35 +56,28 @@ install(
   DESTINATION "${INSTALL_DIR}/include"
 )
 
-# The actual underlying CSP library, needs to sit alongside the bindings.
-# Including this makes this a complete artifact.
-if (BUILD_SHARED_LIBS)
+# ---------------- CSP Runtime (only if shared) ----------------
+
+get_target_property(_CSP_TYPE _CSP TYPE)
+
+if(_CSP_TYPE STREQUAL "SHARED_LIBRARY")
+  message(STATUS "Installing CSP as shared runtime dependency")
+
   install(
-    FILES $<TARGET_FILE:_CSP>
-    DESTINATION ${INSTALL_DIR}/bin
+    TARGETS _CSP
+    RUNTIME DESTINATION "${INSTALL_DIR}/bin"
+    LIBRARY DESTINATION "${INSTALL_DIR}/lib"
   )
-endif()
 
-if(APPLE)
-    if(CMAKE_SYSTEM_NAME STREQUAL "iOS" OR CMAKE_SYSTEM_NAME STREQUAL "visionOS")
-        # Copy the original CSP libraries alongside the one we created via SWIG
-        install(DIRECTORY "${_CSP_LIB_DIR}/"
-                DESTINATION "${INSTALL_DIR}/lib")
-    endif()
-endif()
+  if(MSVC)
+    install(FILES "${_CSP_LIB_DIR}/ConnectedSpacesPlatform_D.pdb"
+            DESTINATION "${INSTALL_DIR}/bin"
+            CONFIGURATIONS Debug)
 
-# Finally the underlying CSP's debug symbols on windows platforms (no pdb equivalent on unix).
-# TARGET_PDB_FILE is not available for imported targets (why though?)
-# So do it more explicitly.
-if(MSVC AND BUILD_SHARED_LIBS)
-  install(FILES "${_CSP_LIB_DIR}/ConnectedSpacesPlatform_D.pdb"
-          DESTINATION "${INSTALL_DIR}/bin"
-          CONFIGURATIONS Debug)
-
-  install(FILES "${_CSP_LIB_DIR}/ConnectedSpacesPlatform.pdb"
-          DESTINATION "${INSTALL_DIR}/bin"
-          CONFIGURATIONS RelWithDebInfo)
-elseif(APPLE AND BUILD_SHARED_LIBS)
+    install(FILES "${_CSP_LIB_DIR}/ConnectedSpacesPlatform.pdb"
+            DESTINATION "${INSTALL_DIR}/bin"
+            CONFIGURATIONS RelWithDebInfo)
+  elseif(APPLE)
     # This is redundant I think, CSP could build DWARF with debug symbols embedded, I don't think dSYMs are the norm?
     install(DIRECTORY "${_CSP_LIB_DIR}/libConnectedSpacesPlatform_D.dylib.dSYM"
             DESTINATION "${INSTALL_DIR}/bin"
@@ -85,4 +86,7 @@ elseif(APPLE AND BUILD_SHARED_LIBS)
     install(DIRECTORY "${_CSP_LIB_DIR}/libConnectedSpacesPlatform.dylib.dSYM"
             DESTINATION "${INSTALL_DIR}/bin"
             CONFIGURATIONS RelWithDebInfo)
+  endif()
+else()
+  message(STATUS "CSP is static and embedded — not installing CSP separately")
 endif()


### PR DESCRIPTION
Instead of being platform specific, the need to install CSP libraries depends on whether we have it statically linked inside the SWIG library (no need to install it separately) or if it is shared library (so it needs to be installed alongside the swig shared library).

The rule Is:

Policy
• If Not shared lib
 → CSP is static and embedded into the SWIG wrapper
 → CSP must NOT be installed separately
• If Shared lib
 → CSP is shared and a runtime dependency
 → CSP MUST be installed alongside the SWIG wrapper

 Note by platform:
 - iOS -> needs static CSP static SWIG -> no separate CSP ship
 - visionOS -> needs static CSP static SWIG -> no separate CSP ship
 - Android -> needs shared CSP shared SWIG -> need separate CSP ship
 - Quest -> needs shared CSP shared SWIG -> need separate CSP ship
 - Windows -> needs static CSP shared SWIG -> no separate CSP ship
 - macOS -> needs static CSP shared SWIG -> no separate CSP ship