### PR TITLE
[OPE-3224] Download targeted version of CSP instead of latest

### DIFF
--- a/Doc/Implementor-Guide.md
+++ b/Doc/Implementor-Guide.md
@@ -687,7 +687,7 @@ To invoke the full build as normal, running the configure, build and install pha
 rmdir build -r; rmdir install -r; cmake -S . -B build; cmake --build build --config Debug; cmake --install build --config Debug
 ```
 
-By default, the project will download the latest CSP release from github each time you build. If you wish to use a specific, local version of CSP, you can do that via doing `-B build -DCSP_ROOT_DIR="C:/path/to/CSPRelease` in the build command. `CSPRelease` should be a folder packaged in the same format as the downloaded CSP release from github, ie it contains `include`, `lib`, etc.
+By default, the project will download a specific version of CSP release from github using the git tag specified by the cmake variable CSP_TARGET_VERSION (see [GetCSP.cmake](https://github.com/magnopus-opensource/connected-spaces-platform-unity/blob/main/cmake/GetCSP.cmake)) each time you build. If you wish to use a specific local version of CSP, you can do that via doing `-B build -DCSP_ROOT_DIR="C:/path/to/CSPRelease` in the build command. `CSPRelease` should be a folder packaged in the same format as the downloaded CSP release from github, ie it contains `include`, `lib`, etc.
 
 Build artifacts, including the downloaded CSP, can be found in the ephemeral build directory. (`build` if using the above command) Two subfolders are particularly relevant.
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ To use the install output in unity, copy the files like so:
 
 ### Dependencies
 - [CMake](https://cmake.org/): Version 3.28 or greater 
-- [Github CLI](https://cli.github.com/): You must have the github command line tools installed and activated in order to discover and download the latest CSP release.
+- [Github CLI](https://cli.github.com/): You must have the github command line tools installed and activated in order to discover and download a specific CSP release version.
 - (For Android) [Android NDK](https://developer.android.com/ndk/downloads): Tested with specific version `29.0.14206865`, but most should work.  
 
 ### Relevant CMake Variables
@@ -139,5 +139,6 @@ To use the install output in unity, copy the files like so:
 | `ROOT_I_DIR`| Path | Directory where the root `.i` SWIG interface file can be found. Defaults to `./interface`. The root `.i` file should be called `main.i`                                                                                                                         |
 | `CSP_ROOT_DIR` | Path | Path to the root directory of a CSP release. Include directories are used in SWIG `.i` files, and provided binaries are linked against. This is normally downloaded automatically, and will be set by default to `BUILD_FOLDER/_deps/connected-spaces-platform` |
 | `SWIG_EXE`| Path | Path to the directory containing the swig executable that is used to generate .cpp and .cs code. This is normally downloaded automatically, and will be set by default to `BUILD_FOLDER/_deps/swig-il2cpp-directors/bin/swig`                                   |
+| `CSP_TARGET_VERSION`| String | Git tag representing the CSP release version targeted by the SWIG build.                                                                                                                                     |
 | `CSP_LIB_UNITY_DIR`| Path | Path to Unity CSP plugin directory where the CSP generated code and libs from SWIG will be copied to, if desired.                                                                                                                                               |
 | `CSP_ASMDEF_PATH`| Path | Path to ConnectedSpacesPlatform Unity .asmdef file, which will be used in Unity to handle the dependency over the CSP code.                                                                                                                                     |

--- a/cmake/GetCSP.cmake
+++ b/cmake/GetCSP.cmake
@@ -40,7 +40,7 @@ endif()
 if(NOT DEFINED CSP_ROOT_DIR)
   set(CSP_ROOT_DIR "${_DEPS_DIR}/connected-spaces-platform" CACHE PATH "Path to Connected Spaces Platform root")
 
-  # This is necessary to find the latest CSP release.
+  # This is necessary to find the specific CSP release version we are looking for.
   # This dependency could be removed if CSP omitted the build number from its release naming.
   # Then we could pin to a CSP_RELEASE_NUMBER variable, and deduce the URL directly.
   find_program(GH_EXECUTABLE gh)
@@ -48,11 +48,13 @@ if(NOT DEFINED CSP_ROOT_DIR)
       message(FATAL_ERROR "GitHub CLI (gh) not found. Please install it and retry. (https://cli.github.com/)")
   endif()
 
-  message(STATUS "Downloading last CSP release according to pattern: '${_CSP_RELEASE_ARTIFACT_PATTERN}'")
+  # Specify the CSP version we want to use for the SWIG build
+  set(CSP_TARGET_VERSION "v6.30.0" CACHE STRING "The CSP release version to download")
+  message(STATUS "Downloading CSP release version: '${CSP_TARGET_VERSION}'")
 
-  # Download Latest CSP Release
+  # Download specific CSP version using a Git tag
   execute_process(
-      COMMAND gh release download --repo magnopus-opensource/connected-spaces-platform --pattern ${_CSP_RELEASE_ARTIFACT_PATTERN} --skip-existing --dir ${_DEPS_DIR}
+      COMMAND gh release download ${CSP_TARGET_VERSION} --repo magnopus-opensource/connected-spaces-platform --pattern ${_CSP_RELEASE_ARTIFACT_PATTERN} --skip-existing --dir ${_DEPS_DIR}
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
       RESULT_VARIABLE res
   )


### PR DESCRIPTION
Ticket: https://magnopus.atlassian.net/browse/OPE-3224

### Summary ###
This change allows us to target a specific CSP version, so that if a new CSP release with breaking changes is published and the current state of the repo did not yet account for them (like it happened today), nothing will break.

The currently targeted version is:

**CSP v6.30.0**