### PR TITLE
OPE-3175 Fix workflow to use unity or dotnet exclusively

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1 # VS Developer Cmd Prompt. We need this for NMake Makefiles (Ninja would also work)
 
       - name: Configure
-        run: cmake -G "NMake Makefiles" -DCMAKE_TOOLCHAIN_FILE="$env:ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake" -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-21 -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON -S . -B build ${{ matrix.build_with_unity_extensions && '-DENABLE_UNITY_EXTENSIONS=ON' || '' }} -DENABLE_THROW_EXCEPTION_ON_RESULTBASE_FAILURE=ON
+        run: cmake -G "NMake Makefiles" -DCMAKE_TOOLCHAIN_FILE="$env:ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake" -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-21 -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON -S . -B build -DENABLE_UNITY_EXTENSIONS=${{ matrix.build_with_unity_extensions && 'ON' || 'OFF' }} -DENABLE_THROW_EXCEPTION_ON_RESULTBASE_FAILURE=ON
 
       - name: Build
         run: cmake --build build --config ${{ matrix.build_type }}
@@ -57,6 +57,6 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: android-${{ matrix.os }}-${{ matrix.build_type }}${{ matrix.build_with_unity_extensions && '-UnityExtensions' || '' }}
+          name: android-${{ matrix.os }}-${{ matrix.build_type }}${{ matrix.build_with_unity_extensions && '-Unity' || '-DotNet' }}
           path: install/**
           if-no-files-found: error

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -42,7 +42,7 @@ jobs:
           dotnet-version: '8.x'
 
       - name: Configure
-        run: cmake -S . -B build ${{ matrix.build_with_unity_extensions && '-DENABLE_UNITY_EXTENSIONS=ON' || '' }}
+        run: cmake -S . -B build -DENABLE_UNITY_EXTENSIONS=${{ matrix.build_with_unity_extensions && 'ON' || 'OFF' }}
 
       - name: Build
         run: cmake --build build --config ${{ matrix.build_type }}
@@ -64,6 +64,6 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: desktop-${{ matrix.os }}-${{ matrix.build_type }}${{ matrix.build_with_unity_extensions && '-UnityExtensions' || '' }}
+          name: desktop-${{ matrix.os }}-${{ matrix.build_type }}${{ matrix.build_with_unity_extensions && '-Unity' || '-DotNet' }}
           path: install/**
           if-no-files-found: error

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure
-        run: cmake -S . -B build -G Xcode -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphoneos -DCMAKE_OSX_ARCHITECTURES="arm64" -DBUILD_SHARED_LIBS=OFF ${{ matrix.build_with_unity_extensions && '-DENABLE_UNITY_EXTENSIONS=ON' || '' }}
+        run: cmake -S . -B build -G Xcode -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphoneos -DCMAKE_OSX_ARCHITECTURES="arm64" -DBUILD_SHARED_LIBS=OFF -DENABLE_UNITY_EXTENSIONS=${{ matrix.build_with_unity_extensions && 'ON' || 'OFF' }}
 
       - name: Build
         run: cmake --build build --config ${{ matrix.build_type }}
@@ -55,6 +55,6 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: iOS-${{ matrix.os }}-${{ matrix.build_type }}${{ matrix.build_with_unity_extensions && '-UnityExtensions' || '' }}
+          name: iOS-${{ matrix.os }}-${{ matrix.build_type }}${{ matrix.build_with_unity_extensions && '-Unity' || '-DotNet' }}
           path: install/**
           if-no-files-found: error

--- a/.github/workflows/make-release-dotnet.yml
+++ b/.github/workflows/make-release-dotnet.yml
@@ -3,27 +3,14 @@ name: Package DotNet Zip and Publish to Release Branch
 on:
   workflow_dispatch:
     inputs:
-      version:
-        required: true
-      releaseTag:
-        required: true
-      is_official_release:
-        type: boolean
-        default: false
+      version: { required: true, type: string, description: "Version label (e.g., v0.0.1)" }
+      releaseTag: { required: true, type: string, description: "Git tag to make for this release" }
+      is_official_release: { type: boolean, default: false, description: "If true, pushes to release/dotnet branch"}
   workflow_call:
     inputs:
-      version:
-        type: string
-        required: true
-      releaseTag:
-        type: string
-        required: true
-      is_official_release:
-        type: boolean
-        default: false
-
-env:
-  DEFAULT_VERSION: '0.0.1'
+      version: { type: string, required: true }
+      releaseTag: { type: string, required: true }
+      is_official_release: { type: boolean, default: false }
 
 jobs:
   check-branch:
@@ -38,21 +25,18 @@ jobs:
   build-android:
     needs: check-branch
     uses: ./.github/workflows/build-android.yml
-    with:
-      unity_ext_matrix: '[false]'
+    with: { unity_ext_matrix: '[false]' }
   build-desktop:
     needs: check-branch
     uses: ./.github/workflows/build-desktop.yml
-    with:
-      unity_ext_matrix: '[false]'
+    with: { unity_ext_matrix: '[false]' }
   build-ios:
     needs: check-branch
     uses: ./.github/workflows/build-ios.yml
-    with:
-      unity_ext_matrix: '[false]'
+    with: { unity_ext_matrix: '[false]' }
 
   package-dotnet:
-    needs: [check-branch, build-android, build-desktop, build-ios]
+    needs: [ check-branch, build-android, build-desktop, build-ios ]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -95,44 +79,42 @@ jobs:
           if [ -n "$INCLUDE_DIR" ]; then cp -R "$INCLUDE_DIR"/* DotNet/include; fi
           
           zip -r "${{ env.ZIP_NAME }}.zip" ./DotNet/*
-
-      - name: Push Source-Only to release/dotnet
-        # Logic: Mirror the Unity strategy for .NET consumers.
-        # Keeps a logic-only history for standard C# developers.
-        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main' || github.ref_name == 'OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively') }} # TEMP FOR TESTING, TODO: REMOVE!
-        shell: bash
-        run: |
-          # Identify the "author" of the commit as the GitHub Actions bot so the push isn't rejected.
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           
-          # Separate logic from artifacts.
-          mkdir -p dist-dotnet
-          cp -r DotNet/* dist-dotnet/
-          
-          # Strip the 400MB native 'libs' folder.
-          # This keeps the .git folder lightweight and prevents performance degradation.
-          rm -rf dist-dotnet/libs 
-          
-          # Switch to the dedicated .NET distribution branch.
-          git fetch origin release/dotnet || true
-          git checkout release/dotnet || git checkout --orphan release/dotnet
-          
-          # Clean out the old version completely to prevent file ghosting.
-          git rm -rf . > /dev/null
-          mv dist-dotnet/* .
-          
-          # Commit and Push the new 'logic snapshot'.
-          git add .
-          git commit -m "DotNet Release ${{ inputs.version }}"
-          git push origin release/dotnet
-          
-          # Create a dotnet-specific tag for version-controlled source reference.
-          git tag -f "dotnet/${{ inputs.version }}"
-          git push origin "dotnet/${{ inputs.version }}"
-
       - name: Upload DotNet Zip Artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ZIP_NAME }}
           path: "${{ env.ZIP_NAME }}.zip"
+
+      - name: Push Source-Only to release/dotnet
+        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main' || github.ref_name == 'OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively') }}
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          # 1. Stage logic OUTSIDE workspace
+          mkdir -p ../dist-dotnet-temp
+          cp -r DotNet/* ../dist-dotnet-temp/
+          rm -rf ../dist-dotnet-temp/libs 
+          
+          # 2. Switch branch
+          git fetch origin release/dotnet || true
+          git checkout release/dotnet || git checkout --orphan release/dotnet
+          
+          # 3. Cleanup: 
+          # Remove tracked files from Git index first
+          git rm -rf . --ignore-unmatch > /dev/null
+          
+          # Delete all physical files/folders in the root EXCEPT the .git folder
+          # This prevents the "Directory not empty" error
+          ls -A | grep -v "^.git$" | xargs rm -rf
+          
+          # 4. Restore logic
+          mv ../dist-dotnet-temp/* .
+          
+          git add .
+          git commit -m "DotNet Release ${{ inputs.version }}"
+          git push origin release/dotnet
+          git tag -f "dotnet/${{ inputs.version }}"
+          git push origin "dotnet/${{ inputs.version }}"

--- a/.github/workflows/make-release-dotnet.yml
+++ b/.github/workflows/make-release-dotnet.yml
@@ -1,3 +1,14 @@
+# ==============================================================================
+# Make Release: DotNet
+#
+# PURPOSE:
+# This workflow assembles the C# wrappers and native C++ binaries into a ZIP
+# file for GitHub Releases. 
+#
+# If triggered as an official release (is_official_release = true), it also
+# invokes the `publish_branch.sh` script to push the lightweight source-code-only 
+# package to the 'release/dotnet' branch, keeping heavy binaries out of Git.
+# ==============================================================================
 name: Package DotNet Zip and Publish to Release Branch
 
 on:
@@ -46,6 +57,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Make Scripts Executable
+        run: chmod +x Utilities/CI/*.sh
+
       - name: Calculate Filename
         run: |
           CLEAN_VERSION="${{ inputs.version }}"
@@ -63,23 +77,11 @@ jobs:
           pattern: '*DotNet*'
 
       - name: Assemble DotNet Structure
-        run: |
-          mkdir -p DotNet/libs/Android/arm64-v8a
-          mkdir -p DotNet/libs/iOS
-          mkdir -p DotNet/libs/macOS
-          mkdir -p DotNet/libs/Windows/x86_64
-          mkdir -p DotNet/include
+        run: ./Utilities/CI/assemble_dotnet.sh
 
-          find artifacts/android-* -name "*.so" -exec cp {} DotNet/libs/Android/arm64-v8a/ \;
-          find artifacts/iOS-* -name "*.a" -exec cp {} DotNet/libs/iOS/ \;
-          find artifacts/desktop-windows-* -name "*.dll" -exec cp {} DotNet/libs/Windows/x86_64/ \;
-          find artifacts/desktop-macos-* -name "*.dylib" -exec cp -R {} DotNet/libs/macOS/ \;
-          
-          INCLUDE_DIR=$(find artifacts -type d -name "include" | head -n 1)
-          if [ -n "$INCLUDE_DIR" ]; then cp -R "$INCLUDE_DIR"/* DotNet/include; fi
-          
-          zip -r "${{ env.ZIP_NAME }}.zip" ./DotNet/*
-          
+      - name: Zip DotNet
+        run: zip -r "${{ env.ZIP_NAME }}.zip" ./DotNet/*
+
       - name: Upload DotNet Zip Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -88,33 +90,4 @@ jobs:
 
       - name: Push Source-Only to release/dotnet
         if: ${{ inputs.is_official_release == true && (github.ref_name == 'main') }}
-        shell: bash
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          
-          # 1. Stage logic OUTSIDE workspace
-          mkdir -p ../dist-dotnet-temp
-          cp -r DotNet/* ../dist-dotnet-temp/
-          rm -rf ../dist-dotnet-temp/libs 
-          
-          # 2. Switch branch
-          git fetch origin release/dotnet || true
-          git checkout release/dotnet || git checkout --orphan release/dotnet
-          
-          # 3. Cleanup: 
-          # Remove tracked files from Git index first
-          git rm -rf . --ignore-unmatch > /dev/null
-          
-          # Delete all physical files/folders in the root EXCEPT the .git folder
-          # This prevents the "Directory not empty" error
-          ls -A | grep -v "^.git$" | xargs rm -rf
-          
-          # 4. Restore logic
-          mv ../dist-dotnet-temp/* .
-          
-          git add .
-          git commit -m "DotNet Release ${{ inputs.version }}"
-          git push origin release/dotnet
-          git tag -f "dotnet/${{ inputs.version }}"
-          git push origin "dotnet/${{ inputs.version }}"
+        run: ./Utilities/CI/publish_branch.sh "DotNet" "release/dotnet" "${{ inputs.version }}" "libs"

--- a/.github/workflows/make-release-dotnet.yml
+++ b/.github/workflows/make-release-dotnet.yml
@@ -9,6 +9,10 @@ on:
       releaseTag:
         description: 'Git tag to make for this release'
         required: true
+      is_official_release:
+        description: 'Is this an official release (no test suffix)?'
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       version:
@@ -17,6 +21,12 @@ on:
       releaseTag:
         type: string
         required: true
+      is_official_release:
+        type: boolean
+        default: false
+
+env:
+  DEFAULT_VERSION: '0.0.1'
 
 jobs:
   # 1. Validate branch first
@@ -55,6 +65,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Calculate Filename
+        shell: bash
+        run: |
+          VERSION_INPUT="${{ inputs.version || env.DEFAULT_VERSION }}"
+          CLEAN_VERSION="${VERSION_INPUT#v}"
+          CURRENT_BRANCH="${{ github.ref_name }}"
+          
+          # SAFETY CHECK: Match Unity logic
+          if [[ "${{ inputs.is_official_release }}" == "true" && "$CURRENT_BRANCH" == "main" ]]; then
+             echo "✅ Official DotNet release confirmed."
+             FINAL_FILENAME="CSP-DotNet-${CLEAN_VERSION}"
+          else
+             echo "ℹ️ Using test suffix for DotNet ZIP."
+             FINAL_FILENAME="CSP-DotNet-${CLEAN_VERSION}-test"
+          fi
+          echo "ZIP_NAME=$FINAL_FILENAME" >> $GITHUB_ENV
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -85,16 +112,12 @@ jobs:
           
           # Navigate into the folder before zipping
           cd DotNet
-          
-          # Zip the package (with a fallback name 'test-build' for when triggered by a push)
-          zip -r ../CSP-DotNet-${{ github.event.inputs.version || 'test-build' }}.zip ./*
-          
-          # Go back to the root workspace just to be clean
-          cd ..
+          # Use the environment variable for the filename
+          zip -r "../${{ env.ZIP_NAME }}.zip" ./*
 
       - name: Upload DotNet Zip Artifact
         uses: actions/upload-artifact@v4
         with:
-          # Use the exact same fallback name here!
-          name: CSP-DotNet-${{ github.event.inputs.version || 'test-build' }}
-          path: CSP-DotNet-${{ github.event.inputs.version || 'test-build' }}.zip
+          # Use the variable calculated in the "Calculate Filename" step
+          name: ${{ env.ZIP_NAME }}
+          path: "${{ env.ZIP_NAME }}.zip"

--- a/.github/workflows/make-release-dotnet.yml
+++ b/.github/workflows/make-release-dotnet.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Verify branch
         run: |
-          if [ "${{ github.ref }}" != "refs/heads/main" ] && [ "${{ github.ref }}" != "refs/heads/OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively" ]; then
+          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
             exit 1
           fi
   
@@ -87,7 +87,7 @@ jobs:
           path: "${{ env.ZIP_NAME }}.zip"
 
       - name: Push Source-Only to release/dotnet
-        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main' || github.ref_name == 'OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively') }}
+        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main') }}
         shell: bash
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/make-release-dotnet.yml
+++ b/.github/workflows/make-release-dotnet.yml
@@ -58,9 +58,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Make Scripts Executable
-        run: chmod +x Utilities/CI/*.sh
-
       - name: Calculate Filename
         run: |
           CLEAN_VERSION="${{ inputs.version }}"
@@ -78,7 +75,7 @@ jobs:
           pattern: '*DotNet*'
 
       - name: Assemble DotNet Structure
-        run: ./Utilities/CI/assemble_dotnet.sh
+        run: bash Utilities/CI/assemble_dotnet.sh
 
       - name: Zip DotNet
         run: zip -r "${{ env.ZIP_NAME }}.zip" ./DotNet/*
@@ -92,4 +89,4 @@ jobs:
       - name: Push Source-Only to release/dotnet
         # TODO: Remove custom branch check once tests cannot push anymore!
         if: ${{ inputs.is_official_release == true && (github.ref_name == 'main' || github.ref_name == 'OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively') }}
-        run: ./Utilities/CI/publish_branch.sh "DotNet" "release/dotnet" "${{ inputs.version }}" "libs"
+        run: bash Utilities/CI/publish_branch.sh "DotNet" "release/dotnet" "${{ inputs.version }}" "libs"

--- a/.github/workflows/make-release-dotnet.yml
+++ b/.github/workflows/make-release-dotnet.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Push Source-Only to release/dotnet
         # Logic: Mirror the Unity strategy for .NET consumers.
         # Keeps a logic-only history for standard C# developers.
-        if: ${{ inputs.is_official_release == true && github.ref_name == 'main' }}
+        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main' || github.ref_name == 'OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively') }} # TEMP FOR TESTING, TODO: REMOVE!
         shell: bash
         run: |
           # Identify the "author" of the commit as the GitHub Actions bot so the push isn't rejected.

--- a/.github/workflows/make-release-dotnet.yml
+++ b/.github/workflows/make-release-dotnet.yml
@@ -85,6 +85,15 @@ jobs:
           name: ${{ env.ZIP_NAME }}
           path: "${{ env.ZIP_NAME }}.zip"
 
-      - name: Push Source-Only to release/dotnet
-        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main') }}
-        run: bash Utilities/CI/publish_branch.sh "DotNet" "release/dotnet" "${{ inputs.version }}" "libs"
+      - name: Push Source-Only to release/dotnet or dry run
+        if: ${{ github.ref_name == 'main' }}
+        run: |
+          # Determine if we should actually push or just simulate
+          DRY_RUN_FLAG=""
+          if [[ "${{ inputs.is_official_release }}" != "true" ]]; then
+            DRY_RUN_FLAG="--dry-run"
+            echo "Starting DRY RUN: Verifying release/dotnet assembly without pushing."
+          else
+            echo "Starting OFFICIAL RELEASE: Pushing to release/dotnet."
+          fi
+          bash Utilities/CI/publish_branch.sh "DotNet" "release/dotnet" "${{ inputs.version }}" "libs" $DRY_RUN_FLAG

--- a/.github/workflows/make-release-dotnet.yml
+++ b/.github/workflows/make-release-dotnet.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Verify branch is main or test branch
         run: |
-          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
+          if [ "${{ github.ref }}" != "refs/heads/main" ] && [ "${{ github.ref }}" != "refs/heads/OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively" ]; then
             echo "::error::This workflow can only be run on the main branch. You selected: ${{ github.ref }}"
             exit 1
           fi
@@ -59,6 +59,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
+          pattern: '*DotNet*'
 
       - name: Assemble DotNet Folder Structure
         run: |

--- a/.github/workflows/make-release-dotnet.yml
+++ b/.github/workflows/make-release-dotnet.yml
@@ -29,8 +29,7 @@ jobs:
     steps:
       - name: Verify branch
         run: |
-          # TODO: Remove custom branch check once tests cannot push anymore!
-          if [ "${{ github.ref }}" != "refs/heads/main" ] && [ "${{ github.ref }}" != "refs/heads/OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively" ]; then
+          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
             exit 1
           fi
   
@@ -87,6 +86,5 @@ jobs:
           path: "${{ env.ZIP_NAME }}.zip"
 
       - name: Push Source-Only to release/dotnet
-        # TODO: Remove custom branch check once tests cannot push anymore!
-        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main' || github.ref_name == 'OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively') }}
+        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main') }}
         run: bash Utilities/CI/publish_branch.sh "DotNet" "release/dotnet" "${{ inputs.version }}" "libs"

--- a/.github/workflows/make-release-dotnet.yml
+++ b/.github/workflows/make-release-dotnet.yml
@@ -14,7 +14,7 @@ name: Package DotNet Zip and Publish to Release Branch
 on:
   workflow_dispatch:
     inputs:
-      version: { required: true, type: string, description: "Version label (e.g., v0.0.1)" }
+      version: { required: true, type: string, description: "Version label (e.g., v0.0.2)" }
       releaseTag: { required: true, type: string, description: "Git tag to make for this release" }
       is_official_release: { type: boolean, default: false, description: "If true, pushes to release/dotnet branch"}
   workflow_call:
@@ -29,7 +29,8 @@ jobs:
     steps:
       - name: Verify branch
         run: |
-          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
+          # TODO: Remove custom branch check once tests cannot push anymore!
+          if [ "${{ github.ref }}" != "refs/heads/main" ] && [ "${{ github.ref }}" != "refs/heads/OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively" ]; then
             exit 1
           fi
   
@@ -89,5 +90,6 @@ jobs:
           path: "${{ env.ZIP_NAME }}.zip"
 
       - name: Push Source-Only to release/dotnet
-        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main') }}
+        # TODO: Remove custom branch check once tests cannot push anymore!
+        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main' || github.ref_name == 'OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively') }}
         run: ./Utilities/CI/publish_branch.sh "DotNet" "release/dotnet" "${{ inputs.version }}" "libs"

--- a/.github/workflows/make-release-dotnet.yml
+++ b/.github/workflows/make-release-dotnet.yml
@@ -1,16 +1,13 @@
-name: Package DotNet Zip
+name: Package DotNet Zip and Publish to Release Branch
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version label (e.g., v1.0.0)'
         required: true
       releaseTag:
-        description: 'Git tag to make for this release'
         required: true
       is_official_release:
-        description: 'Is this an official release (no test suffix)?'
         type: boolean
         default: false
   workflow_call:
@@ -29,58 +26,51 @@ env:
   DEFAULT_VERSION: '0.0.1'
 
 jobs:
-  # 1. Validate branch first
   check-branch:
     runs-on: ubuntu-latest
     steps:
-      - name: Verify branch is main or test branch
+      - name: Verify branch
         run: |
           if [ "${{ github.ref }}" != "refs/heads/main" ] && [ "${{ github.ref }}" != "refs/heads/OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively" ]; then
-            echo "::error::This workflow can only be run on the main branch. You selected: ${{ github.ref }}"
             exit 1
           fi
   
-  # 2. Run builds in parallel
   build-android:
     needs: check-branch
     uses: ./.github/workflows/build-android.yml
     with:
-      unity_ext_matrix: '[false]' # Do not build Unity extensions
+      unity_ext_matrix: '[false]'
   build-desktop:
     needs: check-branch
     uses: ./.github/workflows/build-desktop.yml
     with:
-      unity_ext_matrix: '[false]' # Do not build Unity extensions
+      unity_ext_matrix: '[false]'
   build-ios:
     needs: check-branch
     uses: ./.github/workflows/build-ios.yml
     with:
-      unity_ext_matrix: '[false]' # Do not build Unity extensions
+      unity_ext_matrix: '[false]'
 
-  # 3. Package the results
   package-dotnet:
     needs: [check-branch, build-android, build-desktop, build-ios]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Calculate Filename
-        shell: bash
         run: |
-          VERSION_INPUT="${{ inputs.version || env.DEFAULT_VERSION }}"
-          CLEAN_VERSION="${VERSION_INPUT#v}"
-          CURRENT_BRANCH="${{ github.ref_name }}"
-          
-          # SAFETY CHECK: Match Unity logic
-          if [[ "${{ inputs.is_official_release }}" == "true" && "$CURRENT_BRANCH" == "main" ]]; then
-             echo "✅ Official DotNet release confirmed."
-             FINAL_FILENAME="CSP-DotNet-${CLEAN_VERSION}"
+          CLEAN_VERSION="${{ inputs.version }}"
+          CLEAN_VERSION="${CLEAN_VERSION#v}"
+          if [[ "${{ inputs.is_official_release }}" == "true" && "${{ github.ref_name }}" == "main" ]]; then
+             echo "ZIP_NAME=CSP-DotNet-${CLEAN_VERSION}" >> $GITHUB_ENV
           else
-             echo "ℹ️ Using test suffix for DotNet ZIP."
-             FINAL_FILENAME="CSP-DotNet-${CLEAN_VERSION}-test"
+             echo "ZIP_NAME=CSP-DotNet-${CLEAN_VERSION}-test" >> $GITHUB_ENV
           fi
-          echo "ZIP_NAME=$FINAL_FILENAME" >> $GITHUB_ENV
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -88,7 +78,7 @@ jobs:
           path: artifacts
           pattern: '*DotNet*'
 
-      - name: Assemble DotNet Folder Structure
+      - name: Assemble DotNet Structure
         run: |
           mkdir -p DotNet/libs/Android/arm64-v8a
           mkdir -p DotNet/libs/iOS
@@ -96,28 +86,53 @@ jobs:
           mkdir -p DotNet/libs/Windows/x86_64
           mkdir -p DotNet/include
 
-          # Using 'find' to scoop up BOTH Debug and Release files simultaneously
           find artifacts/android-* -name "*.so" -exec cp {} DotNet/libs/Android/arm64-v8a/ \;
           find artifacts/iOS-* -name "*.a" -exec cp {} DotNet/libs/iOS/ \;
           find artifacts/desktop-windows-* -name "*.dll" -exec cp {} DotNet/libs/Windows/x86_64/ \;
-          
-          # Use cp -R for macOS .bundle because they are directories, not single files
           find artifacts/desktop-macos-* -name "*.dylib" -exec cp -R {} DotNet/libs/macOS/ \;
           
-          # Copy Include Headers
           INCLUDE_DIR=$(find artifacts -type d -name "include" | head -n 1)
-          if [ -n "$INCLUDE_DIR" ]; then
-            cp -R "$INCLUDE_DIR"/* DotNet/include
-          fi
+          if [ -n "$INCLUDE_DIR" ]; then cp -R "$INCLUDE_DIR"/* DotNet/include; fi
           
-          # Navigate into the folder before zipping
-          cd DotNet
-          # Use the environment variable for the filename
-          zip -r "../${{ env.ZIP_NAME }}.zip" ./*
+          zip -r "${{ env.ZIP_NAME }}.zip" ./DotNet/*
+
+      - name: Push Source-Only to release/dotnet
+        # Logic: Mirror the Unity strategy for .NET consumers.
+        # Keeps a logic-only history for standard C# developers.
+        if: ${{ inputs.is_official_release == true && github.ref_name == 'main' }}
+        shell: bash
+        run: |
+          # Identify the "author" of the commit as the GitHub Actions bot so the push isn't rejected.
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          # Separate logic from artifacts.
+          mkdir -p dist-dotnet
+          cp -r DotNet/* dist-dotnet/
+          
+          # Strip the 400MB native 'libs' folder.
+          # This keeps the .git folder lightweight and prevents performance degradation.
+          rm -rf dist-dotnet/libs 
+          
+          # Switch to the dedicated .NET distribution branch.
+          git fetch origin release/dotnet || true
+          git checkout release/dotnet || git checkout --orphan release/dotnet
+          
+          # Clean out the old version completely to prevent file ghosting.
+          git rm -rf . > /dev/null
+          mv dist-dotnet/* .
+          
+          # Commit and Push the new 'logic snapshot'.
+          git add .
+          git commit -m "DotNet Release ${{ inputs.version }}"
+          git push origin release/dotnet
+          
+          # Create a dotnet-specific tag for version-controlled source reference.
+          git tag -f "dotnet/${{ inputs.version }}"
+          git push origin "dotnet/${{ inputs.version }}"
 
       - name: Upload DotNet Zip Artifact
         uses: actions/upload-artifact@v4
         with:
-          # Use the variable calculated in the "Calculate Filename" step
           name: ${{ env.ZIP_NAME }}
           path: "${{ env.ZIP_NAME }}.zip"

--- a/.github/workflows/make-release-unity.yml
+++ b/.github/workflows/make-release-unity.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Verify branch is main or test branch
         run: |
-          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
+          if [ "${{ github.ref }}" != "refs/heads/main" ] && [ "${{ github.ref }}" != "refs/heads/OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively" ]; then
             echo "::error::This workflow can only be run on the main branch. You selected: ${{ github.ref }}"
             exit 1
           fi
@@ -59,6 +59,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
+          pattern: '*Unity*'
 
       - name: Assemble Unity Folder Structure
         run: |
@@ -72,10 +73,10 @@ jobs:
           # Using 'find' to scoop up BOTH Debug and Release files simultaneously
           find artifacts/android-* -name "*.so" -exec cp {} UnityPackage/Plugins/Android/libs/arm64-v8a/ \;
           find artifacts/iOS-* -name "*.a" -exec cp {} UnityPackage/Plugins/iOS/ \;
-          find artifacts/desktop-windows-*-UnityExtensions -name "*.dll" -exec cp {} UnityPackage/Plugins/Windows/x86_64/ \;
+          find artifacts/desktop-windows-*-Unity -name "*.dll" -exec cp {} UnityPackage/Plugins/Windows/x86_64/ \;
           
-          # Use cp -R for macOS .bundle because they are directories, not single files
-          find artifacts/desktop-macos-*-UnityExtensions -name "*.dylib" -exec cp -R {} UnityPackage/Plugins/macOS/ \;
+          # Use cp -R for macOS .dylib because they are directories, not single files
+          find artifacts/desktop-macos-*-Unity -name "*.dylib" -exec cp -R {} UnityPackage/Plugins/macOS/ \;
           
           # Copy Include Headers
           # Finds the first 'include' directory in the artifacts and copies its contents.

--- a/.github/workflows/make-release-unity.yml
+++ b/.github/workflows/make-release-unity.yml
@@ -1,14 +1,22 @@
-name: Package Unity Zip
+name: Package Unity and Publish to GitHub Registry
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version label (e.g., v1.0.0)'
+        description: 'Version label (e.g., v0.0.1)'
         required: true
       releaseTag:
         description: 'Git tag to make for this release'
         required: true
+      publish_to_npm:
+        description: 'Enable NPM publish to GitHub Registry'
+        type: boolean
+        default: false
+      is_official_release:
+        description: 'If true, ignores the random hex suffix'
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       version:
@@ -17,9 +25,18 @@ on:
       releaseTag:
         type: string
         required: true
+      publish_to_npm:
+        type: boolean
+        default: false
+      is_official_release:
+        type: boolean
+        default: false
+
+env:
+  DEFAULT_VERSION: '0.0.1'
 
 jobs:
-  # 1. Validate branch first
+  # Validate branch first
   check-branch:
     runs-on: ubuntu-latest
     steps:
@@ -29,8 +46,8 @@ jobs:
             echo "::error::This workflow can only be run on the main branch. You selected: ${{ github.ref }}"
             exit 1
           fi
-  
-  # 2. Run builds in parallel
+
+  # Run builds in parallel
   build-android:
     needs: check-branch
     uses: ./.github/workflows/build-android.yml
@@ -47,13 +64,48 @@ jobs:
     with:
       unity_ext_matrix: '[true]' # Only build Unity extensions
 
-  # 3. Package the results
+  # Package and Publish
   package-unity:
     needs: [check-branch, build-android, build-desktop, build-ios]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # Required to publish to GitHub Packages
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Calculate Version and Check Collision
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION_INPUT="${{ inputs.version || env.DEFAULT_VERSION }}"
+          CLEAN_VERSION="${VERSION_INPUT#v}"
+          CURRENT_BRANCH="${{ github.ref_name }}"
+          
+          # SAFETY CHECK: Only allow official releases from 'main'
+          if [[ "${{ inputs.is_official_release }}" == "true" && "$CURRENT_BRANCH" == "main" ]]; then
+            echo "✅ Official release confirmed on main. Proceeding without suffix."
+            UNIQUE_VERSION="$CLEAN_VERSION"
+          else
+            if [[ "${{ inputs.is_official_release }}" == "true" ]]; then
+              echo "::warning::Official release requested on '$CURRENT_BRANCH'. Forcing test suffix for safety."
+            fi
+            RANDOM_HASH=$(openssl rand -hex 4 | cut -c1-7)
+            UNIQUE_VERSION="${CLEAN_VERSION}-test.${RANDOM_HASH}"
+          fi
+          
+          echo "UNIQUE_VERSION=$UNIQUE_VERSION" >> $GITHUB_ENV
+          
+          if [[ "${{ inputs.publish_to_npm }}" == "true" ]]; then
+            echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
+            PACKAGE_NAME="@magnopus-opensource/com.magnopus.csp.unity"
+            if npm view "$PACKAGE_NAME@$UNIQUE_VERSION" version --registry=https://npm.pkg.github.com > /dev/null 2>&1; then
+              echo "::error::Version $UNIQUE_VERSION already exists in registry!"
+              exit 1
+            fi
+          fi
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -70,51 +122,69 @@ jobs:
           mkdir -p UnityPackage/Runtime
           mkdir -p UnityPackage/Editor
 
-          # Using 'find' to scoop up BOTH Debug and Release files simultaneously
+          # Copy Native Binaries
           find artifacts/android-* -name "*.so" -exec cp {} UnityPackage/Plugins/Android/libs/arm64-v8a/ \;
           find artifacts/iOS-* -name "*.a" -exec cp {} UnityPackage/Plugins/iOS/ \;
           find artifacts/desktop-windows-*-Unity -name "*.dll" -exec cp {} UnityPackage/Plugins/Windows/x86_64/ \;
-          
-          # Use cp -R for macOS .dylib because they are directories, not single files
           find artifacts/desktop-macos-*-Unity -name "*.dylib" -exec cp -R {} UnityPackage/Plugins/macOS/ \;
           
-          # Copy Include Headers
-          # Finds the first 'include' directory in the artifacts and copies its contents.
-          # Note that the code shoulod already be the same for all platforms by now.
+          # Copy SWIG Headers/Source
           INCLUDE_DIR=$(find artifacts -type d -name "include" | head -n 1)
           if [ -n "$INCLUDE_DIR" ]; then
             cp -R "$INCLUDE_DIR"/* UnityPackage/Runtime
           fi
           
           # Copy Editor Scripts from Repo
-          # Using cp -r to recursively copy all files and folders inside that repo path.
-          # The '|| true' ensures the workflow doesn't crash if the folder is ever empty or moved.
           cp -r UnityProject/extra/Editor/* UnityPackage/Editor/ || true
-          # Also copy the asmdef file to let Unity detect the script in the Runtime folder
           cp UnityProject/extra/ConnectedSpacesPlatform.Unity.Core.asmdef UnityPackage/Runtime/ || true
 
-      - name: Generate package.json
+      - name: Generate package.json and Publish
         shell: bash
         run: |
-          # Standard portable shell expansion to strip 'v'
-          VERSION_STR="${{ inputs.version }}"
-          CLEAN_VERSION="${VERSION_STR#v}"
-
-          # Call our universal CMake script
+          VERSION_INPUT="${{ inputs.version || env.DEFAULT_VERSION }}"
+          CLEAN_VERSION="${VERSION_INPUT#v}"
+          # Use UNIQUE_VERSION (with or without hex based on toggle) or fallback to CLEAN_VERSION
+          FINAL_VERSION="${UNIQUE_VERSION:-$CLEAN_VERSION}"
+          
           cmake -D "TEMPLATE=UnityProject/extra/package.json.template" \
-                -D "OUTPUT=UnityPackage/package.json" \
-                -D "VERSION=$CLEAN_VERSION" \
-                -P cmake/GeneratePackageJson.cmake
+             -D "OUTPUT=UnityPackage/package.json" \
+             -D "VERSION=$FINAL_VERSION" \
+             -P cmake/GeneratePackageJson.cmake
+          
+          # Filename for the .tgz release asset
+          tar -czf "com.magnopus.csp.unity-${VERSION_INPUT}.tgz" -C UnityPackage .
 
-      - name: Create Tarball
+      - name: Publish to Registry
+        if: ${{ inputs.publish_to_npm == true }}
         shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Using tar -C to change directory so the 'UnityPackage' folder name 
-          # isn't inside the archive, only its contents.
-          tar -czf "com.magnopus.csp-${{ inputs.version }}.tgz" -C UnityPackage .
-      
+          echo "@magnopus-opensource:registry=https://npm.pkg.github.com" > UnityPackage/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> UnityPackage/.npmrc
+          cd UnityPackage
+          npm publish
+
       - name: Upload Unity Tarball Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: com.magnopus.csp-${{ inputs.version }}
-          path: com.magnopus.csp-${{ inputs.version }}.tgz
+          name: com.magnopus.csp.unity-${{ inputs.version || 'test-build' }}
+          path: "*.tgz"
+
+      - name: Generate Workflow Summary
+        if: always()
+        shell: bash
+        run: |
+          echo "## 📦 Unity Package Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "* **Base Version:** ${{ inputs.version || env.DEFAULT_VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "* **Official Release:** ${{ inputs.is_official_release }}" >> $GITHUB_STEP_SUMMARY
+          
+          if [[ "${{ inputs.publish_to_npm }}" == "true" ]]; then
+            echo "* **Registry Status:** ✅ Published to GitHub Packages" >> $GITHUB_STEP_SUMMARY
+            echo "* **Internal Version:** \`${{ env.UNIQUE_VERSION }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "* **Registry URL:** [View Package on GitHub](https://github.com/orgs/magnopus-opensource/packages/npm/package/com.magnopus.csp.unity)" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "* **Registry Status:** ⏭️ Skipped" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          echo "* **Tarball Created:** \`com.magnopus.csp.unity-${{ inputs.version || env.DEFAULT_VERSION }}.tgz\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/make-release-unity.yml
+++ b/.github/workflows/make-release-unity.yml
@@ -157,7 +157,7 @@ jobs:
           git fetch origin release/unity || true
           git checkout release/unity || git checkout --orphan release/unity
           
-          # 3. IMPROVED CLEANUP
+          # 3. Cleanup
           git rm -rf . --ignore-unmatch > /dev/null
           ls -A | grep -v "^.git$" | xargs rm -rf
           

--- a/.github/workflows/make-release-unity.yml
+++ b/.github/workflows/make-release-unity.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Push Source-Only to release/unity
         # We only update the distribution branch for official releases from main.
         # This keeps the 'release/unity' branch as a clean, production-only timeline.
-        if: ${{ inputs.is_official_release == true && github.ref_name == 'main' }}
+        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main' || github.ref_name == 'OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively') }} # TEMP FOR TESTING, TODO: REMOVE!
         shell: bash
         run: |
           # Identify the "author" of the commit as the GitHub Actions bot so the push isn't rejected.

--- a/.github/workflows/make-release-unity.yml
+++ b/.github/workflows/make-release-unity.yml
@@ -62,9 +62,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Make Scripts Executable
-        run: chmod +x Utilities/CI/*.sh
-
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -72,7 +69,7 @@ jobs:
           pattern: '*Unity*'
 
       - name: Assemble Unity Package
-        run: ./Utilities/CI/assemble_unity.sh "${{ inputs.version }}" "${{ inputs.releaseTag }}" "${{ github.repository }}"
+        run: bash Utilities/CI/assemble_unity.sh "${{ inputs.version }}" "${{ inputs.releaseTag }}" "${{ github.repository }}"
 
       - name: Generate Missing Unity .meta Files
         run: python Utilities/CI/generate_unity_meta.py
@@ -89,4 +86,4 @@ jobs:
       - name: Push Source-Only to release/unity
         # TODO: Remove custom branch check once tests cannot push anymore!
         if: ${{ inputs.is_official_release == true && (github.ref_name == 'main' || github.ref_name == 'OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively') }}
-        run: ./Utilities/CI/publish_branch.sh "UnityPackage" "release/unity" "${{ inputs.version }}" "Plugins"
+        run: bash Utilities/CI/publish_branch.sh "UnityPackage" "release/unity" "${{ inputs.version }}" "Plugins"

--- a/.github/workflows/make-release-unity.yml
+++ b/.github/workflows/make-release-unity.yml
@@ -86,6 +86,44 @@ jobs:
              -D "VERSION=$CLEAN_VERSION" \
              -P cmake/GeneratePackageJson.cmake
 
+      - name: Generate Missing Unity .meta Files
+        shell: python
+        run: |
+          import os, uuid
+          
+          def generate_meta(target_path, is_dir, is_cs):
+              meta_path = target_path + '.meta'
+          
+              # Skip if a .meta file already exists
+              if os.path.exists(meta_path):
+                  return
+          
+              guid = uuid.uuid4().hex
+              content = f"fileFormatVersion: 2\nguid: {guid}\n"
+          
+              if is_dir:
+                  content += "folderAsset: yes\nDefaultImporter:\n  externalObjects: {}\n  userData: \n  assetBundleName: \n  assetBundleVariant: \n"
+              elif is_cs:
+                  content += "MonoImporter:\n  externalObjects: {}\n  serializedVersion: 2\n  iconMap: {}\n  executionOrder: 0\n"
+              else:
+                  content += "DefaultImporter:\n  externalObjects: {}\n  userData: \n  assetBundleName: \n  assetBundleVariant: \n"
+          
+              with open(meta_path, 'w', encoding='utf-8') as f:
+                  f.write(content)
+
+          package_root = 'UnityPackage'
+          
+          for root, dirs, files in os.walk(package_root):
+              for dir_name in dirs:
+                  if dir_name.startswith('.'): continue
+                  target = os.path.join(root, dir_name)
+                  generate_meta(target, is_dir=True, is_cs=False)
+          
+              for file_name in files:
+                  if file_name.endswith('.meta') or file_name.startswith('.'): continue
+                  target = os.path.join(root, file_name)
+                  generate_meta(target, is_dir=False, is_cs=file_name.endswith('.cs'))
+
       - name: Create Full Tarball (For Release Page)
         run: tar -czf "com.magnopus.csp.unity-${{ inputs.version }}.tgz" -C UnityPackage .
 

--- a/.github/workflows/make-release-unity.yml
+++ b/.github/workflows/make-release-unity.yml
@@ -75,7 +75,6 @@ jobs:
         run: ./Utilities/CI/assemble_unity.sh "${{ inputs.version }}" "${{ inputs.releaseTag }}" "${{ github.repository }}"
 
       - name: Generate Missing Unity .meta Files
-        shell: python
         run: python Utilities/CI/generate_unity_meta.py
 
       - name: Create Full Tarball (For Release Page)

--- a/.github/workflows/make-release-unity.yml
+++ b/.github/workflows/make-release-unity.yml
@@ -82,6 +82,15 @@ jobs:
           name: com.magnopus.csp.unity-${{ inputs.version }}
           path: "*.tgz"
 
-      - name: Push Source-Only to release/unity
-        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main') }}
-        run: bash Utilities/CI/publish_branch.sh "UnityPackage" "release/unity" "${{ inputs.version }}" "Plugins"
+      - name: Push Source-Only to release/unity or dry run
+        if: ${{ github.ref_name == 'main' }}
+        run: |
+          # Determine if we should actually push or just simulate
+          DRY_RUN_FLAG=""
+          if [[ "${{ inputs.is_official_release }}" != "true" ]]; then
+            DRY_RUN_FLAG="--dry-run"
+            echo "Starting DRY RUN: Verifying release/unity assembly without pushing."
+          else
+            echo "Starting OFFICIAL RELEASE: Pushing to release/unity."
+          fi
+          bash Utilities/CI/publish_branch.sh "UnityPackage" "release/unity" "${{ inputs.version }}" "Plugins" $DRY_RUN_FLAG

--- a/.github/workflows/make-release-unity.yml
+++ b/.github/workflows/make-release-unity.yml
@@ -32,8 +32,7 @@ jobs:
     steps:
       - name: Verify branch
         run: |
-          # TODO: Remove custom branch check once tests cannot push anymore!
-          if [ "${{ github.ref }}" != "refs/heads/main" ] && [ "${{ github.ref }}" != "refs/heads/OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively" ]; then
+          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
             echo "::error::Unauthorized branch"
             exit 1
           fi
@@ -84,6 +83,5 @@ jobs:
           path: "*.tgz"
 
       - name: Push Source-Only to release/unity
-        # TODO: Remove custom branch check once tests cannot push anymore!
-        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main' || github.ref_name == 'OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively') }}
+        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main') }}
         run: bash Utilities/CI/publish_branch.sh "UnityPackage" "release/unity" "${{ inputs.version }}" "Plugins"

--- a/.github/workflows/make-release-unity.yml
+++ b/.github/workflows/make-release-unity.yml
@@ -77,14 +77,22 @@ jobs:
           cp -r UnityProject/extra/Editor/* UnityPackage/Editor/ || true
           cp UnityProject/extra/ConnectedSpacesPlatform.Unity.Core.asmdef UnityPackage/Runtime/ || true
 
-      - name: Generate package.json
+      - name: Generate Package Metadata
         run: |
           CLEAN_VERSION="${{ inputs.version }}"
           CLEAN_VERSION="${CLEAN_VERSION#v}"
+          
+          # 1. Generate package.json
           cmake -D "TEMPLATE=UnityProject/extra/package.json.template" \
              -D "OUTPUT=UnityPackage/package.json" \
              -D "VERSION=$CLEAN_VERSION" \
              -P cmake/GeneratePackageJson.cmake
+          
+          # 2. Generate package-dist.json before the Python script runs
+          echo '{
+            "version": "${{ inputs.version }}",
+            "downloadUrl": "https://github.com/${{ github.repository }}/releases/download/${{ inputs.releaseTag }}/com.magnopus.csp.unity-${{ inputs.version }}.tgz"
+          }' > UnityPackage/package-dist.json
 
       - name: Generate Missing Unity .meta Files
         shell: python
@@ -140,12 +148,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
-          # 1. Metadata and Temp Staging
-          echo '{
-            "version": "${{ inputs.version }}",
-            "downloadUrl": "https://github.com/${{ github.repository }}/releases/download/${{ inputs.releaseTag }}/com.magnopus.csp.unity-${{ inputs.version }}.tgz"
-          }' > UnityPackage/package-dist.json
-          
+          # 1. Temp Staging
           mkdir -p ../dist-unity-temp
           cp -r UnityPackage/* ../dist-unity-temp/
           rm -rf ../dist-unity-temp/Plugins 

--- a/.github/workflows/make-release-unity.yml
+++ b/.github/workflows/make-release-unity.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Verify branch
         run: |
-          if [ "${{ github.ref }}" != "refs/heads/main" ] && [ "${{ github.ref }}" != "refs/heads/OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively" ]; then
+          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
             echo "::error::Unauthorized branch"
             exit 1
           fi
@@ -142,7 +142,7 @@ jobs:
           path: "*.tgz"
 
       - name: Push Source-Only to release/unity
-        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main' || github.ref_name == 'OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively') }}
+        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main') }}
         shell: bash
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/make-release-unity.yml
+++ b/.github/workflows/make-release-unity.yml
@@ -14,7 +14,7 @@ name: Package Unity and Publish to Release Branch
 on:
   workflow_dispatch:
     inputs:
-      version: { required: true, type: string, description: "Version label (e.g., v0.0.1)" }
+      version: { required: true, type: string, description: "Version label (e.g., v0.0.2)" }
       releaseTag: { required: true, type: string, description: "Git tag to make for this release" }
       is_official_release: { type: boolean, default: false, description: "If true, pushes to release/unity branch" }
   workflow_call:
@@ -24,7 +24,7 @@ on:
       is_official_release: { type: boolean, default: false }
 
 env:
-  DEFAULT_VERSION: '0.0.1'
+  DEFAULT_VERSION: '0.0.2'
 
 jobs:
   check-branch:
@@ -32,7 +32,8 @@ jobs:
     steps:
       - name: Verify branch
         run: |
-          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
+          # TODO: Remove custom branch check once tests cannot push anymore!
+          if [ "${{ github.ref }}" != "refs/heads/main" ] && [ "${{ github.ref }}" != "refs/heads/OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively" ]; then
             echo "::error::Unauthorized branch"
             exit 1
           fi
@@ -87,5 +88,6 @@ jobs:
           path: "*.tgz"
 
       - name: Push Source-Only to release/unity
-        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main') }}
+        # TODO: Remove custom branch check once tests cannot push anymore!
+        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main' || github.ref_name == 'OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively') }}
         run: ./Utilities/CI/publish_branch.sh "UnityPackage" "release/unity" "${{ inputs.version }}" "Plugins"

--- a/.github/workflows/make-release-unity.yml
+++ b/.github/workflows/make-release-unity.yml
@@ -1,3 +1,14 @@
+# ==============================================================================
+# Make Release: Unity
+#
+# PURPOSE:
+# This workflow assembles the C# wrappers and native C++ binaries into a TGZ
+# file for GitHub Releases. 
+#
+# If triggered as an official release (is_official_release = true), it also
+# invokes the `publish_branch.sh` script to push the lightweight source-code-only 
+# package to the 'release/unity' branch, keeping heavy binaries out of Git.
+# ==============================================================================
 name: Package Unity and Publish to Release Branch
 
 on:
@@ -50,87 +61,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Make Scripts Executable
+        run: chmod +x Utilities/CI/*.sh
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
           pattern: '*Unity*'
 
-      - name: Assemble Unity Folder Structure
-        run: |
-          mkdir -p UnityPackage/Plugins/Android/libs/arm64-v8a
-          mkdir -p UnityPackage/Plugins/iOS
-          mkdir -p UnityPackage/Plugins/macOS
-          mkdir -p UnityPackage/Plugins/Windows/x86_64
-          mkdir -p UnityPackage/Runtime
-          mkdir -p UnityPackage/Editor
-
-          # Copy Native Binaries (Heavy)
-          find artifacts/android-* -name "*.so" -exec cp {} UnityPackage/Plugins/Android/libs/arm64-v8a/ \;
-          find artifacts/iOS-* -name "*.a" -exec cp {} UnityPackage/Plugins/iOS/ \;
-          find artifacts/desktop-windows-*-Unity -name "*.dll" -exec cp {} UnityPackage/Plugins/Windows/x86_64/ \;
-          find artifacts/desktop-macos-*-Unity -name "*.dylib" -exec cp -R {} UnityPackage/Plugins/macOS/ \;
-          
-          # Copy Source/Metadata
-          INCLUDE_DIR=$(find artifacts -type d -name "include" | head -n 1)
-          if [ -n "$INCLUDE_DIR" ]; then cp -R "$INCLUDE_DIR"/* UnityPackage/Runtime; fi
-          cp -r UnityProject/extra/Editor/* UnityPackage/Editor/ || true
-          cp UnityProject/extra/ConnectedSpacesPlatform.Unity.Core.asmdef UnityPackage/Runtime/ || true
-
-      - name: Generate Package Metadata
-        run: |
-          CLEAN_VERSION="${{ inputs.version }}"
-          CLEAN_VERSION="${CLEAN_VERSION#v}"
-          
-          # 1. Generate package.json
-          cmake -D "TEMPLATE=UnityProject/extra/package.json.template" \
-             -D "OUTPUT=UnityPackage/package.json" \
-             -D "VERSION=$CLEAN_VERSION" \
-             -P cmake/GeneratePackageJson.cmake
-          
-          # 2. Generate package-dist.json before the Python script runs
-          echo '{
-            "version": "${{ inputs.version }}",
-            "downloadUrl": "https://github.com/${{ github.repository }}/releases/download/${{ inputs.releaseTag }}/com.magnopus.csp.unity-${{ inputs.version }}.tgz"
-          }' > UnityPackage/package-dist.json
+      - name: Assemble Unity Package
+        run: ./Utilities/CI/assemble_unity.sh "${{ inputs.version }}" "${{ inputs.releaseTag }}" "${{ github.repository }}"
 
       - name: Generate Missing Unity .meta Files
         shell: python
-        run: |
-          import os, uuid
-          
-          def generate_meta(target_path, is_dir, is_cs):
-              meta_path = target_path + '.meta'
-          
-              # Skip if a .meta file already exists
-              if os.path.exists(meta_path):
-                  return
-          
-              guid = uuid.uuid4().hex
-              content = f"fileFormatVersion: 2\nguid: {guid}\n"
-          
-              if is_dir:
-                  content += "folderAsset: yes\nDefaultImporter:\n  externalObjects: {}\n  userData: \n  assetBundleName: \n  assetBundleVariant: \n"
-              elif is_cs:
-                  content += "MonoImporter:\n  externalObjects: {}\n  serializedVersion: 2\n  iconMap: {}\n  executionOrder: 0\n"
-              else:
-                  content += "DefaultImporter:\n  externalObjects: {}\n  userData: \n  assetBundleName: \n  assetBundleVariant: \n"
-          
-              with open(meta_path, 'w', encoding='utf-8') as f:
-                  f.write(content)
-
-          package_root = 'UnityPackage'
-          
-          for root, dirs, files in os.walk(package_root):
-              for dir_name in dirs:
-                  if dir_name.startswith('.'): continue
-                  target = os.path.join(root, dir_name)
-                  generate_meta(target, is_dir=True, is_cs=False)
-          
-              for file_name in files:
-                  if file_name.endswith('.meta') or file_name.startswith('.'): continue
-                  target = os.path.join(root, file_name)
-                  generate_meta(target, is_dir=False, is_cs=file_name.endswith('.cs'))
+        run: python Utilities/CI/generate_unity_meta.py
 
       - name: Create Full Tarball (For Release Page)
         run: tar -czf "com.magnopus.csp.unity-${{ inputs.version }}.tgz" -C UnityPackage .
@@ -143,29 +88,4 @@ jobs:
 
       - name: Push Source-Only to release/unity
         if: ${{ inputs.is_official_release == true && (github.ref_name == 'main') }}
-        shell: bash
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          
-          # 1. Temp Staging
-          mkdir -p ../dist-unity-temp
-          cp -r UnityPackage/* ../dist-unity-temp/
-          rm -rf ../dist-unity-temp/Plugins 
-          
-          # 2. Switch branch
-          git fetch origin release/unity || true
-          git checkout release/unity || git checkout --orphan release/unity
-          
-          # 3. Cleanup
-          git rm -rf . --ignore-unmatch > /dev/null
-          ls -A | grep -v "^.git$" | xargs rm -rf
-          
-          # 4. Restore only source files
-          mv ../dist-unity-temp/* .
-          
-          git add .
-          git commit -m "Unity Release ${{ inputs.version }}"
-          git push origin release/unity
-          git tag -f "unity/${{ inputs.version }}"
-          git push origin "unity/${{ inputs.version }}"
+        run: ./Utilities/CI/publish_branch.sh "UnityPackage" "release/unity" "${{ inputs.version }}" "Plugins"

--- a/.github/workflows/make-release-unity.yml
+++ b/.github/workflows/make-release-unity.yml
@@ -3,34 +3,14 @@ name: Package Unity and Publish to Release Branch
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version label (e.g., v0.0.1)'
-        required: true
-      releaseTag:
-        description: 'Git tag to make for this release'
-        required: true
-      publish_to_npm:
-        description: 'DEPRECATED - Moved to Release Branch Strategy'
-        type: boolean
-        default: false
-      is_official_release:
-        description: 'If true, pushes to release/unity branch'
-        type: boolean
-        default: false
+      version: { required: true, type: string, description: "Version label (e.g., v0.0.1)" }
+      releaseTag: { required: true, type: string, description: "Git tag to make for this release" }
+      is_official_release: { type: boolean, default: false, description: "If true, pushes to release/unity branch" }
   workflow_call:
     inputs:
-      version:
-        type: string
-        required: true
-      releaseTag:
-        type: string
-        required: true
-      publish_to_npm:
-        type: boolean
-        default: false
-      is_official_release:
-        type: boolean
-        default: false
+      version: { type: string, required: true }
+      releaseTag: { type: string, required: true }
+      is_official_release: { type: boolean, default: false }
 
 env:
   DEFAULT_VERSION: '0.0.1'
@@ -42,25 +22,22 @@ jobs:
       - name: Verify branch
         run: |
           if [ "${{ github.ref }}" != "refs/heads/main" ] && [ "${{ github.ref }}" != "refs/heads/OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively" ]; then
-            echo "::error::This workflow must run on main or approved test branches."
+            echo "::error::Unauthorized branch"
             exit 1
           fi
 
   build-android:
     needs: check-branch
     uses: ./.github/workflows/build-android.yml
-    with:
-      unity_ext_matrix: '[true]'
+    with: { unity_ext_matrix: '[true]' }
   build-desktop:
     needs: check-branch
     uses: ./.github/workflows/build-desktop.yml
-    with:
-      unity_ext_matrix: '[true]'
+    with: { unity_ext_matrix: '[true]' }
   build-ios:
     needs: check-branch
     uses: ./.github/workflows/build-ios.yml
-    with:
-      unity_ext_matrix: '[true]'
+    with: { unity_ext_matrix: '[true]' }
 
   package-unity:
     needs: [check-branch, build-android, build-desktop, build-ios]
@@ -94,84 +71,60 @@ jobs:
           find artifacts/desktop-windows-*-Unity -name "*.dll" -exec cp {} UnityPackage/Plugins/Windows/x86_64/ \;
           find artifacts/desktop-macos-*-Unity -name "*.dylib" -exec cp -R {} UnityPackage/Plugins/macOS/ \;
           
-          # Copy SWIG Source (Light)
+          # Copy Source/Metadata
           INCLUDE_DIR=$(find artifacts -type d -name "include" | head -n 1)
           if [ -n "$INCLUDE_DIR" ]; then cp -R "$INCLUDE_DIR"/* UnityPackage/Runtime; fi
-          
           cp -r UnityProject/extra/Editor/* UnityPackage/Editor/ || true
           cp UnityProject/extra/ConnectedSpacesPlatform.Unity.Core.asmdef UnityPackage/Runtime/ || true
 
       - name: Generate package.json
         run: |
-          VERSION_INPUT="${{ inputs.version || env.DEFAULT_VERSION }}"
-          CLEAN_VERSION="${VERSION_INPUT#v}"
+          CLEAN_VERSION="${{ inputs.version }}"
+          CLEAN_VERSION="${CLEAN_VERSION#v}"
           cmake -D "TEMPLATE=UnityProject/extra/package.json.template" \
              -D "OUTPUT=UnityPackage/package.json" \
              -D "VERSION=$CLEAN_VERSION" \
              -P cmake/GeneratePackageJson.cmake
 
-      - name: Create Full Tarball (Binary Release)
+      - name: Create Full Tarball (For Release Page)
         run: tar -czf "com.magnopus.csp.unity-${{ inputs.version }}.tgz" -C UnityPackage .
-
-      - name: Generate Distribution Metadata
-        shell: bash
-        run: |
-          # Define the URL where the full tarball will live on the GitHub Release page
-          # Note: We use the releaseTag calculated in the prep-release job
-          RELEASE_TAG="${{ needs.prep-release.outputs.release_tag }}"
-          PACKAGE_VERSION="${{ inputs.version }}"
-          REPO_FULL_NAME="${{ github.repository }}"
-          
-          DOWNLOAD_URL="https://github.com/${REPO_FULL_NAME}/releases/download/${RELEASE_TAG}/com.magnopus.csp.unity-${PACKAGE_VERSION}.tgz"
-          
-          echo "Generating package-dist.json pointing to $DOWNLOAD_URL"
-          
-          echo '{
-            "version": "'$PACKAGE_VERSION'",
-            "downloadUrl": "'$DOWNLOAD_URL'",
-            "packageName": "com.magnopus.csp.unity"
-          }' > UnityPackage/package-dist.json
-
-      - name: Push Source-Only to release/unity
-        # We only update the distribution branch for official releases from main.
-        # This keeps the 'release/unity' branch as a clean, production-only timeline.
-        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main' || github.ref_name == 'OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively') }} # TEMP FOR TESTING, TODO: REMOVE!
-        shell: bash
-        run: |
-          # Identify the "author" of the commit as the GitHub Actions bot so the push isn't rejected.
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          
-          # Create a 'source-only' version of the package.
-          # This allows developers to diff C# logic without 400MB of binary noise.
-          mkdir -p dist-unity
-          cp -r UnityPackage/* dist-unity/
-          
-          # Remove heavy binaries before committing to Git.
-          # These are hosted on the GitHub Release page instead to prevent repo bloat.
-          rm -rf dist-unity/Plugins 
-          
-          # We use a 'Sync Mirror' approach.
-          # 1. Fetch the existing branch or create a fresh orphan if it's the first run.
-          git fetch origin release/unity || true
-          git checkout release/unity || git checkout --orphan release/unity
-          
-          # 2. Wipe the current branch state to ensure a 1:1 match with the new source.
-          git rm -rf . > /dev/null
-          mv dist-unity/* .
-          
-          # 3. Commit the logic snapshot. This is what developers can 'diff' against.
-          git add .
-          git commit -m "Unity Release ${{ inputs.version }}"
-          git push origin release/unity
-          
-          # 4. Create a specific distribution tag (e.g. unity/v1.0.0).
-          # This is the target for OpenUPM and internal Git-URL installs.
-          git tag -f "unity/${{ inputs.version }}"
-          git push origin "unity/${{ inputs.version }}"
 
       - name: Upload Unity Tarball Artifact
         uses: actions/upload-artifact@v4
         with:
           name: com.magnopus.csp.unity-${{ inputs.version }}
           path: "*.tgz"
+
+      - name: Push Source-Only to release/unity
+        if: ${{ inputs.is_official_release == true && (github.ref_name == 'main' || github.ref_name == 'OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively') }}
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          # 1. Metadata and Temp Staging
+          echo '{
+            "version": "${{ inputs.version }}",
+            "downloadUrl": "https://github.com/${{ github.repository }}/releases/download/${{ inputs.releaseTag }}/com.magnopus.csp.unity-${{ inputs.version }}.tgz"
+          }' > UnityPackage/package-dist.json
+          
+          mkdir -p ../dist-unity-temp
+          cp -r UnityPackage/* ../dist-unity-temp/
+          rm -rf ../dist-unity-temp/Plugins 
+          
+          # 2. Switch branch
+          git fetch origin release/unity || true
+          git checkout release/unity || git checkout --orphan release/unity
+          
+          # 3. IMPROVED CLEANUP
+          git rm -rf . --ignore-unmatch > /dev/null
+          ls -A | grep -v "^.git$" | xargs rm -rf
+          
+          # 4. Restore only source files
+          mv ../dist-unity-temp/* .
+          
+          git add .
+          git commit -m "Unity Release ${{ inputs.version }}"
+          git push origin release/unity
+          git tag -f "unity/${{ inputs.version }}"
+          git push origin "unity/${{ inputs.version }}"

--- a/.github/workflows/make-release-unity.yml
+++ b/.github/workflows/make-release-unity.yml
@@ -1,4 +1,4 @@
-name: Package Unity and Publish to GitHub Registry
+name: Package Unity and Publish to Release Branch
 
 on:
   workflow_dispatch:
@@ -10,11 +10,11 @@ on:
         description: 'Git tag to make for this release'
         required: true
       publish_to_npm:
-        description: 'Enable NPM publish to GitHub Registry'
+        description: 'DEPRECATED - Moved to Release Branch Strategy'
         type: boolean
         default: false
       is_official_release:
-        description: 'If true, ignores the random hex suffix'
+        description: 'If true, pushes to release/unity branch'
         type: boolean
         default: false
   workflow_call:
@@ -36,76 +36,42 @@ env:
   DEFAULT_VERSION: '0.0.1'
 
 jobs:
-  # Validate branch first
   check-branch:
     runs-on: ubuntu-latest
     steps:
-      - name: Verify branch is main or test branch
+      - name: Verify branch
         run: |
           if [ "${{ github.ref }}" != "refs/heads/main" ] && [ "${{ github.ref }}" != "refs/heads/OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively" ]; then
-            echo "::error::This workflow can only be run on the main branch. You selected: ${{ github.ref }}"
+            echo "::error::This workflow must run on main or approved test branches."
             exit 1
           fi
 
-  # Run builds in parallel
   build-android:
     needs: check-branch
     uses: ./.github/workflows/build-android.yml
     with:
-      unity_ext_matrix: '[true]' # Only build Unity extensions
+      unity_ext_matrix: '[true]'
   build-desktop:
     needs: check-branch
     uses: ./.github/workflows/build-desktop.yml
     with:
-      unity_ext_matrix: '[true]' # Only build Unity extensions
+      unity_ext_matrix: '[true]'
   build-ios:
     needs: check-branch
     uses: ./.github/workflows/build-ios.yml
     with:
-      unity_ext_matrix: '[true]' # Only build Unity extensions
+      unity_ext_matrix: '[true]'
 
-  # Package and Publish
   package-unity:
     needs: [check-branch, build-android, build-desktop, build-ios]
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      packages: write # Required to publish to GitHub Packages
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Calculate Version and Check Collision
-        shell: bash
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION_INPUT="${{ inputs.version || env.DEFAULT_VERSION }}"
-          CLEAN_VERSION="${VERSION_INPUT#v}"
-          CURRENT_BRANCH="${{ github.ref_name }}"
-          
-          # SAFETY CHECK: Only allow official releases from 'main'
-          if [[ "${{ inputs.is_official_release }}" == "true" && "$CURRENT_BRANCH" == "main" ]]; then
-            echo "✅ Official release confirmed on main. Proceeding without suffix."
-            UNIQUE_VERSION="$CLEAN_VERSION"
-          else
-            if [[ "${{ inputs.is_official_release }}" == "true" ]]; then
-              echo "::warning::Official release requested on '$CURRENT_BRANCH'. Forcing test suffix for safety."
-            fi
-            RANDOM_HASH=$(openssl rand -hex 4 | cut -c1-7)
-            UNIQUE_VERSION="${CLEAN_VERSION}-test.${RANDOM_HASH}"
-          fi
-          
-          echo "UNIQUE_VERSION=$UNIQUE_VERSION" >> $GITHUB_ENV
-          
-          if [[ "${{ inputs.publish_to_npm }}" == "true" ]]; then
-            echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
-            PACKAGE_NAME="@magnopus-opensource/com.magnopus.csp.unity"
-            if npm view "$PACKAGE_NAME@$UNIQUE_VERSION" version --registry=https://npm.pkg.github.com > /dev/null 2>&1; then
-              echo "::error::Version $UNIQUE_VERSION already exists in registry!"
-              exit 1
-            fi
-          fi
+        with:
+          fetch-depth: 0
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -122,69 +88,90 @@ jobs:
           mkdir -p UnityPackage/Runtime
           mkdir -p UnityPackage/Editor
 
-          # Copy Native Binaries
+          # Copy Native Binaries (Heavy)
           find artifacts/android-* -name "*.so" -exec cp {} UnityPackage/Plugins/Android/libs/arm64-v8a/ \;
           find artifacts/iOS-* -name "*.a" -exec cp {} UnityPackage/Plugins/iOS/ \;
           find artifacts/desktop-windows-*-Unity -name "*.dll" -exec cp {} UnityPackage/Plugins/Windows/x86_64/ \;
           find artifacts/desktop-macos-*-Unity -name "*.dylib" -exec cp -R {} UnityPackage/Plugins/macOS/ \;
           
-          # Copy SWIG Headers/Source
+          # Copy SWIG Source (Light)
           INCLUDE_DIR=$(find artifacts -type d -name "include" | head -n 1)
-          if [ -n "$INCLUDE_DIR" ]; then
-            cp -R "$INCLUDE_DIR"/* UnityPackage/Runtime
-          fi
+          if [ -n "$INCLUDE_DIR" ]; then cp -R "$INCLUDE_DIR"/* UnityPackage/Runtime; fi
           
-          # Copy Editor Scripts from Repo
           cp -r UnityProject/extra/Editor/* UnityPackage/Editor/ || true
           cp UnityProject/extra/ConnectedSpacesPlatform.Unity.Core.asmdef UnityPackage/Runtime/ || true
 
-      - name: Generate package.json and Publish
-        shell: bash
+      - name: Generate package.json
         run: |
           VERSION_INPUT="${{ inputs.version || env.DEFAULT_VERSION }}"
           CLEAN_VERSION="${VERSION_INPUT#v}"
-          # Use UNIQUE_VERSION (with or without hex based on toggle) or fallback to CLEAN_VERSION
-          FINAL_VERSION="${UNIQUE_VERSION:-$CLEAN_VERSION}"
-          
           cmake -D "TEMPLATE=UnityProject/extra/package.json.template" \
              -D "OUTPUT=UnityPackage/package.json" \
-             -D "VERSION=$FINAL_VERSION" \
+             -D "VERSION=$CLEAN_VERSION" \
              -P cmake/GeneratePackageJson.cmake
-          
-          # Filename for the .tgz release asset
-          tar -czf "com.magnopus.csp.unity-${VERSION_INPUT}.tgz" -C UnityPackage .
 
-      - name: Publish to Registry
-        if: ${{ inputs.publish_to_npm == true }}
+      - name: Create Full Tarball (Binary Release)
+        run: tar -czf "com.magnopus.csp.unity-${{ inputs.version }}.tgz" -C UnityPackage .
+
+      - name: Generate Distribution Metadata
         shell: bash
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "@magnopus-opensource:registry=https://npm.pkg.github.com" > UnityPackage/.npmrc
-          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> UnityPackage/.npmrc
-          cd UnityPackage
-          npm publish
+          # Define the URL where the full tarball will live on the GitHub Release page
+          # Note: We use the releaseTag calculated in the prep-release job
+          RELEASE_TAG="${{ needs.prep-release.outputs.release_tag }}"
+          PACKAGE_VERSION="${{ inputs.version }}"
+          REPO_FULL_NAME="${{ github.repository }}"
+          
+          DOWNLOAD_URL="https://github.com/${REPO_FULL_NAME}/releases/download/${RELEASE_TAG}/com.magnopus.csp.unity-${PACKAGE_VERSION}.tgz"
+          
+          echo "Generating package-dist.json pointing to $DOWNLOAD_URL"
+          
+          echo '{
+            "version": "'$PACKAGE_VERSION'",
+            "downloadUrl": "'$DOWNLOAD_URL'",
+            "packageName": "com.magnopus.csp.unity"
+          }' > UnityPackage/package-dist.json
+
+      - name: Push Source-Only to release/unity
+        # We only update the distribution branch for official releases from main.
+        # This keeps the 'release/unity' branch as a clean, production-only timeline.
+        if: ${{ inputs.is_official_release == true && github.ref_name == 'main' }}
+        shell: bash
+        run: |
+          # Identify the "author" of the commit as the GitHub Actions bot so the push isn't rejected.
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          # Create a 'source-only' version of the package.
+          # This allows developers to diff C# logic without 400MB of binary noise.
+          mkdir -p dist-unity
+          cp -r UnityPackage/* dist-unity/
+          
+          # Remove heavy binaries before committing to Git.
+          # These are hosted on the GitHub Release page instead to prevent repo bloat.
+          rm -rf dist-unity/Plugins 
+          
+          # We use a 'Sync Mirror' approach.
+          # 1. Fetch the existing branch or create a fresh orphan if it's the first run.
+          git fetch origin release/unity || true
+          git checkout release/unity || git checkout --orphan release/unity
+          
+          # 2. Wipe the current branch state to ensure a 1:1 match with the new source.
+          git rm -rf . > /dev/null
+          mv dist-unity/* .
+          
+          # 3. Commit the logic snapshot. This is what developers can 'diff' against.
+          git add .
+          git commit -m "Unity Release ${{ inputs.version }}"
+          git push origin release/unity
+          
+          # 4. Create a specific distribution tag (e.g. unity/v1.0.0).
+          # This is the target for OpenUPM and internal Git-URL installs.
+          git tag -f "unity/${{ inputs.version }}"
+          git push origin "unity/${{ inputs.version }}"
 
       - name: Upload Unity Tarball Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: com.magnopus.csp.unity-${{ inputs.version || 'test-build' }}
+          name: com.magnopus.csp.unity-${{ inputs.version }}
           path: "*.tgz"
-
-      - name: Generate Workflow Summary
-        if: always()
-        shell: bash
-        run: |
-          echo "## 📦 Unity Package Build Summary" >> $GITHUB_STEP_SUMMARY
-          echo "* **Base Version:** ${{ inputs.version || env.DEFAULT_VERSION }}" >> $GITHUB_STEP_SUMMARY
-          echo "* **Official Release:** ${{ inputs.is_official_release }}" >> $GITHUB_STEP_SUMMARY
-          
-          if [[ "${{ inputs.publish_to_npm }}" == "true" ]]; then
-            echo "* **Registry Status:** ✅ Published to GitHub Packages" >> $GITHUB_STEP_SUMMARY
-            echo "* **Internal Version:** \`${{ env.UNIQUE_VERSION }}\`" >> $GITHUB_STEP_SUMMARY
-            echo "* **Registry URL:** [View Package on GitHub](https://github.com/orgs/magnopus-opensource/packages/npm/package/com.magnopus.csp.unity)" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "* **Registry Status:** ⏭️ Skipped" >> $GITHUB_STEP_SUMMARY
-          fi
-          
-          echo "* **Tarball Created:** \`com.magnopus.csp.unity-${{ inputs.version || env.DEFAULT_VERSION }}.tgz\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/make-release-unity.yml
+++ b/.github/workflows/make-release-unity.yml
@@ -92,14 +92,29 @@ jobs:
           cp -r UnityProject/extra/Editor/* UnityPackage/Editor/ || true
           # Also copy the asmdef file to let Unity detect the script in the Runtime folder
           cp UnityProject/extra/ConnectedSpacesPlatform.Unity.Core.asmdef UnityPackage/Runtime/ || true
-          
-          # Zip the package
-          cd UnityPackage
-          zip -r ../CSP-Unity-${{ inputs.version || 'test-build' }}.zip ./*
-          cd ..
 
-      - name: Upload Unity Zip Artifact
+      - name: Generate package.json
+        shell: bash
+        run: |
+          # Standard portable shell expansion to strip 'v'
+          VERSION_STR="${{ inputs.version }}"
+          CLEAN_VERSION="${VERSION_STR#v}"
+
+          # Call our universal CMake script
+          cmake -D "TEMPLATE=UnityProject/extra/package.json.template" \
+                -D "OUTPUT=UnityPackage/package.json" \
+                -D "VERSION=$CLEAN_VERSION" \
+                -P cmake/GeneratePackageJson.cmake
+
+      - name: Create Tarball
+        shell: bash
+        run: |
+          # Using tar -C to change directory so the 'UnityPackage' folder name 
+          # isn't inside the archive, only its contents.
+          tar -czf "com.magnopus.csp-${{ inputs.version }}.tgz" -C UnityPackage .
+      
+      - name: Upload Unity Tarball Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: CSP-Unity-${{ inputs.version || 'test-build' }}
-          path: CSP-Unity-${{ inputs.version || 'test-build' }}.zip
+          name: com.magnopus.csp-${{ inputs.version }}
+          path: com.magnopus.csp-${{ inputs.version }}.tgz

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -1,6 +1,8 @@
 name: Make Release
 
 on:
+  push:
+    branches: [ OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively ] # TEMPORARY - TODO: Remove before merging
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -51,4 +51,6 @@ jobs:
           tag_name: ${{ inputs.releaseTag || format('test-tag-{0}', github.run_number) }}
           target_commitish: ${{ github.sha }}
           generate_release_notes: true
-          files: release-artifacts/*.zip
+          files: |
+            release-artifacts/*.zip
+            release-artifacts/*.tgz

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -2,7 +2,7 @@ name: Make Release
 
 on:
   push:
-    branches: [ OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively ] # TEMPORARY - TODO: Remove before merging
+    branches: [ OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively ] # TEMPORARY
   workflow_dispatch:
     inputs:
       version:
@@ -15,12 +15,8 @@ on:
       releaseTag:
         description: 'Custom Git tag (leave empty for automatic)'
         required: false
-      publish_to_npm:
-        description: 'Enable NPM publish'
-        type: boolean
-        default: false
       is_official_release:
-        description: 'Official release (no hex suffix)'
+        description: 'Official release (pushes to release branches)'
         type: boolean
         default: false
 
@@ -28,7 +24,6 @@ env:
   DEFAULT_VERSION: '0.0.1'
 
 jobs:
-  # 1. A simple setup job to determine the Tag and Version once
   prep-release:
     runs-on: ubuntu-latest
     outputs:
@@ -37,10 +32,7 @@ jobs:
     steps:
       - id: calc
         run: |
-          # 1. Get the base version
           VER="${{ github.event.inputs.version || env.DEFAULT_VERSION }}"
-
-          # 2. Determine the Tag
           if [ -n "${{ github.event.inputs.releaseTag }}" ]; then
             TAG="${{ github.event.inputs.releaseTag }}"
           elif [ "${{ github.event.inputs.is_official_release }}" == "true" ]; then
@@ -48,7 +40,6 @@ jobs:
           else
             TAG="test-${VER}-${{ github.run_number }}"
           fi
-
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "version=$VER" >> $GITHUB_OUTPUT
   
@@ -56,23 +47,19 @@ jobs:
   package-unity:
     needs: prep-release
     uses: ./.github/workflows/make-release-unity.yml
-    secrets: inherit # This ensures the child can see the GITHUB_TOKEN
     permissions:
-      contents: read
-      packages: write # This permission is required to publish to GitHub Packages
+      contents: write # REQUIRED to push to release/unity
     with:
       version: ${{ needs.prep-release.outputs.version }}
       releaseTag: ${{ needs.prep-release.outputs.release_tag }}
-      # TEMPORARY: Change from ${{ github.event.inputs.publish_to_npm }} to true
-      # TODO: Remove and use ${{ github.event.inputs.publish_to_npm }} instead, or all commits will publish!
-      publish_to_npm: true
-      # Safety fallback for manual vs push trigger
       is_official_release: ${{ github.event.inputs.is_official_release == true || false }}
 
   # 3. Run DotNet Packaging
   package-dotnet:
     needs: prep-release
     uses: ./.github/workflows/make-release-dotnet.yml
+    permissions:
+      contents: write # REQUIRED to push to release/dotnet
     with:
       version: ${{ needs.prep-release.outputs.version }}
       releaseTag: ${{ needs.prep-release.outputs.release_tag }}
@@ -83,13 +70,13 @@ jobs:
     needs: [prep-release, package-unity, package-dotnet]
     runs-on: ubuntu-latest
     permissions:
-      contents: write # This permission is strictly required to create tags and releases
+      contents: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: release-artifacts
-          merge-multiple: true # This pulls all downloaded files into a single folder
+          merge-multiple: true
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -100,4 +87,4 @@ jobs:
           generate_release_notes: true
           files: |
             release-artifacts/*.zip
-            release-artifacts/com.magnopus.csp.unity-*.tgz
+            release-artifacts/*.tgz

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -32,40 +32,47 @@ jobs:
     steps:
       - id: calc
         run: |
+          # Fallback to DEFAULT_VERSION if inputs don't exist (on push)
           VER="${{ github.event.inputs.version || env.DEFAULT_VERSION }}"
+          
           if [ -n "${{ github.event.inputs.releaseTag }}" ]; then
             TAG="${{ github.event.inputs.releaseTag }}"
           elif [ "${{ github.event.inputs.is_official_release }}" == "true" ]; then
             TAG="$VER"
           else
+            # For push triggers, this will create a tag like 'test-0.0.1-42'
             TAG="test-${VER}-${{ github.run_number }}"
           fi
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "version=$VER" >> $GITHUB_OUTPUT
   
-  # 2. Run Unity Packaging
+  # Run Unity Packaging
   package-unity:
     needs: prep-release
     uses: ./.github/workflows/make-release-unity.yml
     permissions:
-      contents: write # REQUIRED to push to release/unity
+      contents: write
     with:
       version: ${{ needs.prep-release.outputs.version }}
       releaseTag: ${{ needs.prep-release.outputs.release_tag }}
-      is_official_release: ${{ github.event.inputs.is_official_release == true || false }}
+      # FORCE TO TRUE for testing pushes
+      # TODO: Set back the default to false!
+      is_official_release: ${{ github.event.inputs.is_official_release == true || true }}
 
-  # 3. Run DotNet Packaging
+  # Run DotNet Packaging
   package-dotnet:
     needs: prep-release
     uses: ./.github/workflows/make-release-dotnet.yml
     permissions:
-      contents: write # REQUIRED to push to release/dotnet
+      contents: write
     with:
       version: ${{ needs.prep-release.outputs.version }}
       releaseTag: ${{ needs.prep-release.outputs.release_tag }}
-      is_official_release: ${{ github.event.inputs.is_official_release == true || false }}
+      # FORCE TO TRUE for testing pushes
+      # TODO: Set back the default to false!
+      is_official_release: ${{ github.event.inputs.is_official_release == true || true }}
 
-  # 4. Create the Release
+  # Create the Release
   publish-release:
     needs: [prep-release, package-unity, package-dotnet]
     runs-on: ubuntu-latest
@@ -81,7 +88,9 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: ${{ github.event.inputs.releaseName || format('Release {0}', needs.prep-release.outputs.version) }}
+          # Fallback name for push events
+          # TODO: Remove Test from the name once tests cannot push anymore!
+          name: ${{ github.event.inputs.releaseName || format('Test Release {0}', needs.prep-release.outputs.version) }}
           tag_name: ${{ needs.prep-release.outputs.release_tag }}
           target_commitish: ${{ github.sha }}
           generate_release_notes: true

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -1,9 +1,6 @@
 name: Make Release
 
 on:
-  # TODO: Remove push trigger once tests cannot push anymore!
-  push:
-    branches: [ OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively ] # Triggers automatically on push
   workflow_dispatch:
     inputs:
       version:
@@ -56,8 +53,7 @@ jobs:
     with:
       version: ${{ needs.prep-release.outputs.version }}
       releaseTag: ${{ needs.prep-release.outputs.release_tag }}
-      # TODO: Set default back to false once tests cannot push anymore!
-      is_official_release: ${{ github.event.inputs.is_official_release == true || true }}
+      is_official_release: ${{ github.event.inputs.is_official_release == true || false }}
 
   # Run DotNet Packaging
   package-dotnet:
@@ -68,8 +64,7 @@ jobs:
     with:
       version: ${{ needs.prep-release.outputs.version }}
       releaseTag: ${{ needs.prep-release.outputs.release_tag }}
-      # TODO: Set default back to false once tests cannot push anymore!
-      is_official_release: ${{ github.event.inputs.is_official_release == true || true }}
+      is_official_release: ${{ github.event.inputs.is_official_release == true || false }}
 
   # Create the Release
   publish-release:
@@ -88,8 +83,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           # Fallback name for push events
-          # TODO: Remove "Test " from the name once tests cannot push anymore!
-          name: ${{ github.event.inputs.releaseName || format('Test Release {0}', needs.prep-release.outputs.version) }}
+          name: ${{ github.event.inputs.releaseName || format('Release {0}', needs.prep-release.outputs.version) }}
           tag_name: ${{ needs.prep-release.outputs.release_tag }}
           target_commitish: ${{ github.sha }}
           generate_release_notes: true

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -1,12 +1,15 @@
 name: Make Release
 
 on:
+  # TODO: Remove push trigger once tests cannot push anymore!
+  push:
+    branches: [ OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively ] # Triggers automatically on push
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version label (e.g., v0.0.1)'
+        description: 'Version label (e.g., v0.0.2)'
         required: true
-        default: 'v0.0.1'
+        default: 'v0.0.2'
       releaseName:
         description: 'Name of the release'
         required: true
@@ -19,7 +22,7 @@ on:
         default: false
 
 env:
-  DEFAULT_VERSION: '0.0.1'
+  DEFAULT_VERSION: '0.0.2'
 
 jobs:
   prep-release:
@@ -38,7 +41,7 @@ jobs:
           elif [ "${{ github.event.inputs.is_official_release }}" == "true" ]; then
             TAG="$VER"
           else
-            # For push triggers, this will create a tag like 'test-0.0.1-42'
+            # For push triggers, this will create a tag like 'test-0.0.2-42'
             TAG="test-${VER}-${{ github.run_number }}"
           fi
           echo "tag=$TAG" >> $GITHUB_OUTPUT
@@ -53,7 +56,8 @@ jobs:
     with:
       version: ${{ needs.prep-release.outputs.version }}
       releaseTag: ${{ needs.prep-release.outputs.release_tag }}
-      is_official_release: ${{ github.event.inputs.is_official_release == true || false }}
+      # TODO: Set default back to false once tests cannot push anymore!
+      is_official_release: ${{ github.event.inputs.is_official_release == true || true }}
 
   # Run DotNet Packaging
   package-dotnet:
@@ -64,7 +68,8 @@ jobs:
     with:
       version: ${{ needs.prep-release.outputs.version }}
       releaseTag: ${{ needs.prep-release.outputs.release_tag }}
-      is_official_release: ${{ github.event.inputs.is_official_release == true || false }}
+      # TODO: Set default back to false once tests cannot push anymore!
+      is_official_release: ${{ github.event.inputs.is_official_release == true || true }}
 
   # Create the Release
   publish-release:
@@ -83,7 +88,8 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           # Fallback name for push events
-          name: ${{ github.event.inputs.releaseName || format('Release {0}', needs.prep-release.outputs.version) }}
+          # TODO: Remove "Test " from the name once tests cannot push anymore!
+          name: ${{ github.event.inputs.releaseName || format('Test Release {0}', needs.prep-release.outputs.version) }}
           tag_name: ${{ needs.prep-release.outputs.release_tag }}
           target_commitish: ${{ github.sha }}
           generate_release_notes: true

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -1,8 +1,6 @@
 name: Make Release
 
 on:
-  push:
-    branches: [ OPE-3175_Fix-workflow-to-use-unity-or-dotnet-exclusively ] # TEMPORARY
   workflow_dispatch:
     inputs:
       version:
@@ -55,9 +53,7 @@ jobs:
     with:
       version: ${{ needs.prep-release.outputs.version }}
       releaseTag: ${{ needs.prep-release.outputs.release_tag }}
-      # FORCE TO TRUE for testing pushes
-      # TODO: Set back the default to false!
-      is_official_release: ${{ github.event.inputs.is_official_release == true || true }}
+      is_official_release: ${{ github.event.inputs.is_official_release == true || false }}
 
   # Run DotNet Packaging
   package-dotnet:
@@ -68,9 +64,7 @@ jobs:
     with:
       version: ${{ needs.prep-release.outputs.version }}
       releaseTag: ${{ needs.prep-release.outputs.release_tag }}
-      # FORCE TO TRUE for testing pushes
-      # TODO: Set back the default to false!
-      is_official_release: ${{ github.event.inputs.is_official_release == true || true }}
+      is_official_release: ${{ github.event.inputs.is_official_release == true || false }}
 
   # Create the Release
   publish-release:
@@ -89,8 +83,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           # Fallback name for push events
-          # TODO: Remove Test from the name once tests cannot push anymore!
-          name: ${{ github.event.inputs.releaseName || format('Test Release {0}', needs.prep-release.outputs.version) }}
+          name: ${{ github.event.inputs.releaseName || format('Release {0}', needs.prep-release.outputs.version) }}
           tag_name: ${{ needs.prep-release.outputs.release_tag }}
           target_commitish: ${{ github.sha }}
           generate_release_notes: true

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -6,34 +6,81 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version label for the zip files (e.g., v1.0.0)'
+        description: 'Version label (e.g., v0.0.1)'
         required: true
+        default: 'v0.0.1'
       releaseName:
         description: 'Name of the release'
         required: true
       releaseTag:
-        description: 'Git tag to make for this release'
-        required: true
+        description: 'Custom Git tag (leave empty for automatic)'
+        required: false
+      publish_to_npm:
+        description: 'Enable NPM publish'
+        type: boolean
+        default: false
+      is_official_release:
+        description: 'Official release (no hex suffix)'
+        type: boolean
+        default: false
+
+env:
+  DEFAULT_VERSION: '0.0.1'
 
 jobs:
-  # 1. Run Unity Packaging
-  package-unity:
-    uses: ./.github/workflows/make-release-unity.yml
-    with:
-      # If inputs.version is empty (on push), use 'v1.0.0-test'
-      version: ${{ inputs.version || 'v1.0.0-test' }}
-      releaseTag: ${{ inputs.releaseTag || format('test-tag-{0}', github.run_number) }}
+  # 1. A simple setup job to determine the Tag and Version once
+  prep-release:
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.calc.outputs.tag }}
+      version: ${{ steps.calc.outputs.version }}
+    steps:
+      - id: calc
+        run: |
+          # 1. Get the base version
+          VER="${{ github.event.inputs.version || env.DEFAULT_VERSION }}"
 
-  # 2. Run DotNet Packaging
+          # 2. Determine the Tag
+          if [ -n "${{ github.event.inputs.releaseTag }}" ]; then
+            TAG="${{ github.event.inputs.releaseTag }}"
+          elif [ "${{ github.event.inputs.is_official_release }}" == "true" ]; then
+            TAG="$VER"
+          else
+            TAG="test-${VER}-${{ github.run_number }}"
+          fi
+
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "version=$VER" >> $GITHUB_OUTPUT
+  
+  # 2. Run Unity Packaging
+  package-unity:
+    needs: prep-release
+    uses: ./.github/workflows/make-release-unity.yml
+    secrets: inherit # This ensures the child can see the GITHUB_TOKEN
+    permissions:
+      contents: read
+      packages: write # This permission is required to publish to GitHub Packages
+    with:
+      version: ${{ needs.prep-release.outputs.version }}
+      releaseTag: ${{ needs.prep-release.outputs.release_tag }}
+      # TEMPORARY: Change from ${{ github.event.inputs.publish_to_npm }} to true
+      # TODO: Remove and use ${{ github.event.inputs.publish_to_npm }} instead, or all commits will publish!
+      publish_to_npm: true
+      # Safety fallback for manual vs push trigger
+      is_official_release: ${{ github.event.inputs.is_official_release == true || false }}
+
+  # 3. Run DotNet Packaging
   package-dotnet:
+    needs: prep-release
     uses: ./.github/workflows/make-release-dotnet.yml
     with:
-      version: ${{ inputs.version || 'v1.0.0-test' }}
-      releaseTag: ${{ inputs.releaseTag || format('test-tag-{0}', github.run_number) }}
+      version: ${{ needs.prep-release.outputs.version }}
+      releaseTag: ${{ needs.prep-release.outputs.release_tag }}
+      is_official_release: ${{ github.event.inputs.is_official_release == true || false }}
 
-  # 3. Create the Release
+  # 4. Create the Release
   publish-release:
-    needs: [package-unity, package-dotnet]
+    needs: [prep-release, package-unity, package-dotnet]
     runs-on: ubuntu-latest
     permissions:
       contents: write # This permission is strictly required to create tags and releases
@@ -47,10 +94,10 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: ${{ inputs.releaseName || format('Test Release {0}', github.run_number) }}
-          tag_name: ${{ inputs.releaseTag || format('test-tag-{0}', github.run_number) }}
+          name: ${{ github.event.inputs.releaseName || format('Release {0}', needs.prep-release.outputs.version) }}
+          tag_name: ${{ needs.prep-release.outputs.release_tag }}
           target_commitish: ${{ github.sha }}
           generate_release_notes: true
           files: |
             release-artifacts/*.zip
-            release-artifacts/*.tgz
+            release-artifacts/com.magnopus.csp.unity-*.tgz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,17 +55,13 @@ if(ENABLE_THROW_EXCEPTION_ON_RESULTBASE_FAILURE)
     set(THROW_EXCEPTION_ON_RESULTBASE_FAILURE_FLAG "-DTHROW_EXCEPTION_ON_RESULTBASE_FAILURE=1")
 endif()
 
-# Decide SWIG dllimport name per platform.
-set(SWIG_DLLIMPORT_NAME "${_WRAPPER_MODULE_NAME}")
-
-if(CMAKE_SYSTEM_NAME STREQUAL "iOS" OR CMAKE_SYSTEM_NAME STREQUAL "visionOS")
-    # Note: on iOS and visionOS we need __Internal on the DllImport of the PInvoke, or it won't find the symbols.
-    # This is because on iOS, the code gets statically linked into the final executable, and __Internal tells the 
-    # runtime to look for symbols in the main executable binary itself, rather than looking for a separate dynamic library.
-    # More info on the issue here: https://gitlab.com/rdi-eg/docs/-/wikis/Targeting-iOS-on-Unity3D-using-C%23-swig-generated-code---pitfalls-and-gotchas/diff?version_id=130894855efdab4f0cbd9882e7dc35554fea92bd&view=inline
-    message(STATUS "Configuring SWIG for iOS / visionOS (__Internal)")
-    set(SWIG_DLLIMPORT_NAME "__Internal")
-endif()
+# SWIG requires literal strings for -dllimport. 
+# To support dynamic platform switching in C#, we use a placeholder string 
+# and post-process the generated PINVOKE class to replace it with a 
+# reference to the 'LibName' constant defined in main.i.
+# This allows us to change the dll name used by the dllimport depending on
+# the targeted platform (see the LibName constant in main.i for more details). 
+set(DLL_NAME_FOR_LINKING "DLL_NAME_FOR_LINKING_TO_BE_PATCHED")
 
 # Setup SWIG invocation
 add_custom_command(
@@ -80,13 +76,20 @@ add_custom_command(
           -I${_INTERNAL_SWG_SEARCH_PATH_GLOBAL} # Global search path for SWIG .i lib files.
           -c++ -csharp
           -module ${_WRAPPER_MODULE_NAME}
-          -dllimport ${SWIG_DLLIMPORT_NAME}
+          -dllimport "${DLL_NAME_FOR_LINKING}"
           -outdir "${_GEN_CS_DIR}"
           -o "${_CPP_WRAPPER_OUT}"
           ${SWIG_UNITY_FLAG} # Optionally enable unity extensions
           ${THROW_EXCEPTION_ON_RESULTBASE_FAILURE_FLAG} # Optionally generate ThrowOnFailure code when ResultBase is returned with failure status code.
           -v # Still could be verboser ... There's other options if you need them
           "${_ROOT_I_FILE}"
+          
+  # Remove the quotes around the placeholder string, so that it is treated as a variable rather than a literal.
+  # This converts [DllImport("DLL_NAME_FOR_LINKING_TO_BE_PATCHED")] -> [DllImport(LibName)]
+  # Note: we use LibName here because that matches the variable in main.i
+  COMMAND ${CMAKE_COMMAND} -E echo "Patching PInvoke attributes..."
+  COMMAND sed -i "" "s/\"${DLL_NAME_FOR_LINKING}\"/ConnectedSpacesPlatformDotNetPINVOKE.LibName/g" "${_GEN_CS_DIR}/ConnectedSpacesPlatformDotNetPINVOKE.cs"
+  
   DEPENDS "${_ROOT_I_FILE}"
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" 
   VERBATIM
@@ -95,7 +98,8 @@ add_custom_command(
 # ---------------- Build SWIG Output ----------------
 if (BUILD_SHARED_LIBS)
   add_library(${_WRAPPER_MODULE_NAME} SHARED "${_CPP_WRAPPER_OUT}")
-  # Pretty important, make sure we're importing symbols. Otherwise you'll get duplicate template instances and such. Bad times.
+  # Pretty important, make sure we're importing symbols. 
+  # Otherwise you'll get duplicate template instances and such. Bad times.
   target_compile_definitions(${_WRAPPER_MODULE_NAME} PRIVATE USING_CSP_DLL)
 else()
   add_library(${_WRAPPER_MODULE_NAME} STATIC "${_CPP_WRAPPER_OUT}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,9 +87,14 @@ add_custom_command(
   # Remove the quotes around the placeholder string, so that it is treated as a variable rather than a literal.
   # This converts [DllImport("DLL_NAME_FOR_LINKING_TO_BE_PATCHED")] -> [DllImport(LibName)]
   # Note: we use LibName here because that matches the variable in main.i
-  COMMAND ${CMAKE_COMMAND} -E echo "Patching PInvoke attributes..."
-  COMMAND sed -i "" "s/\"${DLL_NAME_FOR_LINKING}\"/ConnectedSpacesPlatformDotNetPINVOKE.LibName/g" "${_GEN_CS_DIR}/ConnectedSpacesPlatformDotNetPINVOKE.cs"
-  
+  COMMAND ${CMAKE_COMMAND} -E echo "Patching PInvoke attributes for cross-platform compatibility..."
+    
+    # Cross-platform replacement logic
+    COMMAND ${CMAKE_COMMAND} -D "FILE_TO_PATCH=${_GEN_CS_DIR}/ConnectedSpacesPlatformDotNetPINVOKE.cs"
+                             -D "OLD_STR=\"${DLL_NAME_FOR_LINKING}\""
+                             -D "NEW_STR=ConnectedSpacesPlatformDotNetPINVOKE.LibName"
+                             -P "${CMAKE_SOURCE_DIR}/cmake/PatchPInvoke.cmake"
+
   DEPENDS "${_ROOT_I_FILE}"
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" 
   VERBATIM

--- a/UnityProject/extra/Editor/CSPLibraryDownloader.cs
+++ b/UnityProject/extra/Editor/CSPLibraryDownloader.cs
@@ -12,6 +12,13 @@ namespace Plugins.Editor
         private const string PackageName = "com.magnopus.csp.unity";
         private const string MenuPath = "MAGNOPUS/Download CSP Libraries";
 
+        // A targeted custom exception for our downstream catchers
+        public class LibraryInstallationException : Exception
+        {
+            public LibraryInstallationException(string message) : base(message) { }
+            public LibraryInstallationException(string message, Exception innerException) : base(message, innerException) { }
+        }
+
         static CSPBinaryDownloader()
         {
             // Check for binaries shortly after the editor opens
@@ -39,12 +46,24 @@ namespace Plugins.Editor
             {
                 if (!File.Exists(metadataPath))
                 {
-                    if (forceManual) Debug.LogError($"[MAGNOPUS] Metadata not found at {metadataPath}. Ensure package is installed via Git.");
+                    if (forceManual) Debug.LogError($"Metadata not found at {metadataPath}. Ensure package is installed via Git.");
                     return;
                 }
 
-                string json = File.ReadAllText(metadataPath);
-                var data = JsonUtility.FromJson<DistributionMetadata>(json);
+                DistributionMetadata data;
+                try
+                {
+                    data = ReadMetadata(metadataPath);
+                }
+                catch (LibraryInstallationException e)
+                {
+                    Debug.LogException(e);
+                    if (forceManual)
+                    {
+                        EditorUtility.DisplayDialog("Error", e.Message, "OK");
+                    }
+                    return;
+                }
 
                 bool proceed = forceManual || EditorUtility.DisplayDialog(
                     "CSP Binaries Missing",
@@ -58,6 +77,28 @@ namespace Plugins.Editor
             }
         }
 
+        private static DistributionMetadata ReadMetadata(string path)
+        {
+            try
+            {
+                string json = File.ReadAllText(path);
+                var data = JsonUtility.FromJson<DistributionMetadata>(json);
+                
+                if (data == null || string.IsNullOrEmpty(data.downloadUrl))
+                    throw new LibraryInstallationException("downloadUrl is empty or malformed in package-dist.json");
+                    
+                return data;
+            }
+            catch (IOException e)
+            {
+                throw new LibraryInstallationException($"Failed to read metadata file at {path}", e);
+            }
+            catch (ArgumentException e)
+            {
+                throw new LibraryInstallationException($"Failed to parse JSON in metadata file at {path}", e);
+            }
+        }
+
         private static void StartEditorDownload(string url, string targetPath)
         {
             UnityWebRequest www = UnityWebRequest.Get(url);
@@ -67,32 +108,68 @@ namespace Plugins.Editor
             EditorApplication.CallbackFunction updateAction = null;
             updateAction = () =>
             {
-                if (www == null) 
-                {
-                    EditorApplication.update -= updateAction;
-                    return;
-                }
+                bool shouldCleanup = false;
 
-                if (!www.isDone)
+                try
                 {
-                    EditorUtility.DisplayProgressBar("Downloading CSP", $"Fetching binaries... {Mathf.RoundToInt(www.downloadProgress * 100)}%", www.downloadProgress);
-                    return;
-                }
+                    if (www == null) 
+                    {
+                        shouldCleanup = true;
+                        return;
+                    }
 
-                // Cleanup
-                EditorUtility.ClearProgressBar();
-                EditorApplication.update -= updateAction;
+                    if (!www.isDone)
+                    {
+                        bool isCanceled = EditorUtility.DisplayCancelableProgressBar(
+                            "Downloading CSP", 
+                            $"Fetching binaries... {Mathf.RoundToInt(www.downloadProgress * 100)}%", 
+                            www.downloadProgress);
 
-                if (www.result == UnityWebRequest.Result.Success)
-                {
-                    ProcessDownload(www.downloadHandler.data, targetPath);
+                        if (isCanceled)
+                        {
+                            www.Abort(); 
+                            shouldCleanup = true;
+                            Debug.Log("CSP Binary download was canceled by the user.");
+                        }
+                        return; // Exit normally, wait for next frame
+                    }
+
+                    // If we reach here, the download naturally finished
+                    shouldCleanup = true;
+
+                    if (www.result == UnityWebRequest.Result.Success)
+                    {
+                        ProcessDownload(www.downloadHandler.data, targetPath);
+                    }
+                    else
+                    {
+                        var webEx = new LibraryInstallationException($"Network error during download: {www.error}");
+                        Debug.LogException(webEx);
+                        EditorUtility.DisplayDialog("Download Failed", $"Could not download binaries: {www.error}", "OK");
+                    }
                 }
-                else
+                catch (Exception e)
                 {
-                    EditorUtility.DisplayDialog("Download Failed", $"Error: {www.error}", "OK");
+                    // Catch any unexpected errors so they don't break the Editor
+                    Debug.LogException(e);
+                    shouldCleanup = true; 
                 }
-            
-                www.Dispose();
+                finally
+                {
+                    // This guarantees the UI is unblocked and memory is freed, 
+                    // but ONLY when the process is actually terminating!
+                    if (shouldCleanup)
+                    {
+                        EditorUtility.ClearProgressBar();
+                        EditorApplication.update -= updateAction;
+                        
+                        if (www != null)
+                        {
+                            www.Dispose();
+                            www = null; // Null it out to prevent double-disposal
+                        }
+                    }
+                }
             };
 
             EditorApplication.update += updateAction;
@@ -100,29 +177,102 @@ namespace Plugins.Editor
 
         private static void ProcessDownload(byte[] data, string targetFolder)
         {
+            string tempPath = Path.Combine(Application.temporaryCachePath, "csp_binaries.tgz");
+            
             try 
             {
-                if (!Directory.Exists(targetFolder)) Directory.CreateDirectory(targetFolder);
-            
-                string tempPath = Path.Combine(Application.temporaryCachePath, "csp_binaries.tgz");
-                File.WriteAllBytes(tempPath, data);
+                SaveTarball(data, tempPath);
+                ExtractTarball(tempPath, targetFolder);
+                CleanupRedundantFiles(targetFolder);
 
-                Debug.Log($"[MAGNOPUS] Extracting to {targetFolder}...");
-            
-                // Uses system 'tar' (Available on Win 10+, macOS, Linux)
-                System.Diagnostics.ProcessStartInfo startInfo = new System.Diagnostics.ProcessStartInfo
+                AssetDatabase.Refresh();
+                EditorUtility.DisplayDialog("Success", "CSP Binaries successfully installed.", "OK");
+            }
+            catch (LibraryInstallationException e)
+            {
+                Debug.LogException(e);
+                EditorUtility.DisplayDialog("Extraction Error", $"Failed to install binaries:\n{e.Message}", "OK");
+            }
+            finally
+            {
+                if (File.Exists(tempPath)) 
                 {
-                    FileName = "tar",
-                    Arguments = $"-xf \"{tempPath}\" -C \"{targetFolder}\"",
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                };
+                    try
+                    {
+                        File.Delete(tempPath);
+                    }
+                    catch
+                    {
+                         /* Ignore cleanup errors in finally block */
+                    }
+                }
+            }
+        }
 
+        private static void SaveTarball(byte[] data, string savePath)
+        {
+            try
+            {
+                File.WriteAllBytes(savePath, data);
+            }
+            catch (IOException e)
+            {
+                throw new LibraryInstallationException($"Could not write temporary tarball to {savePath}", e);
+            }
+            catch (UnauthorizedAccessException e)
+            {
+                throw new LibraryInstallationException($"Access denied when writing to {savePath}", e);
+            }
+        }
+
+        private static void ExtractTarball(string archivePath, string targetFolder)
+        {
+            try 
+            {
+                if (!Directory.Exists(targetFolder))
+                {
+                    Directory.CreateDirectory(targetFolder);
+                }
+            }
+            catch (Exception e)
+            {
+                throw new LibraryInstallationException($"Failed to create target directory {targetFolder}", e);
+            }
+
+            Debug.Log($"Extracting to {targetFolder}...");
+            
+            // Uses system 'tar' (Available on Win 10+, macOS, Linux)
+            System.Diagnostics.ProcessStartInfo startInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "tar",
+                Arguments = $"-xf \"{archivePath}\" -C \"{targetFolder}\"",
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            try
+            {
                 using (var process = System.Diagnostics.Process.Start(startInfo))
                 {
+                    if (process == null) throw new LibraryInstallationException("Failed to initialize tar process.");
+                    
                     process.WaitForExit();
+                    if (process.ExitCode != 0)
+                    {
+                        throw new LibraryInstallationException($"Tar extraction failed with exit code {process.ExitCode}");
+                    }
                 }
+            }
+            catch (System.ComponentModel.Win32Exception e)
+            {
+                throw new LibraryInstallationException("Failed to start the 'tar' command. Ensure it is available on your system.", e);
+            }
+        }
 
+        private static void CleanupRedundantFiles(string targetFolder)
+        {
+            try
+            {
                 // Remove duplicated C# source folders that were included in the tarball
                 string[] redundantDirs = { "Runtime", "Editor" };
                 foreach (string dir in redundantDirs)
@@ -139,14 +289,14 @@ namespace Plugins.Editor
                     string path = Path.Combine(targetFolder, file);
                     if (File.Exists(path)) File.Delete(path);
                 }
-
-                File.Delete(tempPath);
-                AssetDatabase.Refresh();
-                EditorUtility.DisplayDialog("Success", "CSP Binaries installed in Assets/Plugins/CSP/Internal.", "OK");
             }
-            catch (Exception e)
+            catch (IOException e)
             {
-                Debug.LogError($"[MAGNOPUS] Extraction failed: {e.Message}");
+                throw new LibraryInstallationException("Failed to clean up redundant files after extraction.", e);
+            }
+            catch (UnauthorizedAccessException e)
+            {
+                throw new LibraryInstallationException("Access denied during cleanup of extracted files.", e);
             }
         }
 

--- a/UnityProject/extra/Editor/CSPLibraryDownloader.cs
+++ b/UnityProject/extra/Editor/CSPLibraryDownloader.cs
@@ -123,6 +123,23 @@ namespace Plugins.Editor
                     process.WaitForExit();
                 }
 
+                // Remove duplicated C# source folders that were included in the tarball
+                string[] redundantDirs = { "Runtime", "Editor" };
+                foreach (string dir in redundantDirs)
+                {
+                    string path = Path.Combine(targetFolder, dir);
+                    if (Directory.Exists(path)) Directory.Delete(path, true);
+                    if (File.Exists(path + ".meta")) File.Delete(path + ".meta");
+                }
+
+                // Remove package manifests so they don't clutter the project
+                string[] redundantFiles = { "package.json", "package.json.meta", "package-dist.json", "package-dist.json.meta" };
+                foreach (string file in redundantFiles)
+                {
+                    string path = Path.Combine(targetFolder, file);
+                    if (File.Exists(path)) File.Delete(path);
+                }
+
                 File.Delete(tempPath);
                 AssetDatabase.Refresh();
                 EditorUtility.DisplayDialog("Success", "CSP Binaries installed in Assets/Plugins/CSP/Internal.", "OK");

--- a/UnityProject/extra/Editor/CSPLibraryDownloader.cs
+++ b/UnityProject/extra/Editor/CSPLibraryDownloader.cs
@@ -1,0 +1,144 @@
+using System;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace Plugins.Editor
+{
+    [InitializeOnLoad]
+    public class CSPBinaryDownloader
+    {
+        private const string PackageName = "com.magnopus.csp.unity";
+        private const string MenuPath = "MAGNOPUS/Download CSP Libraries";
+
+        static CSPBinaryDownloader()
+        {
+            // Check for binaries shortly after the editor opens
+            EditorApplication.delayCall += () => CheckForMissingBinaries(false);
+        }
+
+        [MenuItem(MenuPath)]
+        public static void ManualDownloadTrigger()
+        {
+            CheckForMissingBinaries(true);
+        }
+
+        public static void CheckForMissingBinaries(bool forceManual)
+        {
+            string packagePath = Path.GetFullPath($"Packages/{PackageName}");
+            string metadataPath = Path.Combine(packagePath, "package-dist.json");
+        
+            // Target: Assets/Plugins/CSP/Internal (Unity has write access here)
+            string localPluginsPath = Path.Combine(Application.dataPath, "Plugins/CSP/Internal");
+
+            bool binariesExist = Directory.Exists(localPluginsPath) && 
+                                 Directory.GetFiles(localPluginsPath, "*", SearchOption.AllDirectories).Length > 0;
+
+            if (!binariesExist || forceManual)
+            {
+                if (!File.Exists(metadataPath))
+                {
+                    if (forceManual) Debug.LogError($"[MAGNOPUS] Metadata not found at {metadataPath}. Ensure package is installed via Git.");
+                    return;
+                }
+
+                string json = File.ReadAllText(metadataPath);
+                var data = JsonUtility.FromJson<DistributionMetadata>(json);
+
+                bool proceed = forceManual || EditorUtility.DisplayDialog(
+                    "CSP Binaries Missing",
+                    $"The {PackageName} package requires native binaries ({data.version}).\n\nDownload approx 400MB from GitHub?",
+                    "Download", "Skip");
+
+                if (proceed)
+                {
+                    StartEditorDownload(data.downloadUrl, localPluginsPath);
+                }
+            }
+        }
+
+        private static void StartEditorDownload(string url, string targetPath)
+        {
+            UnityWebRequest www = UnityWebRequest.Get(url);
+            www.SendWebRequest();
+
+            // Standard Editor Update loop to handle the download without blocking the UI
+            EditorApplication.CallbackFunction updateAction = null;
+            updateAction = () =>
+            {
+                if (www == null) 
+                {
+                    EditorApplication.update -= updateAction;
+                    return;
+                }
+
+                if (!www.isDone)
+                {
+                    EditorUtility.DisplayProgressBar("Downloading CSP", $"Fetching binaries... {Mathf.RoundToInt(www.downloadProgress * 100)}%", www.downloadProgress);
+                    return;
+                }
+
+                // Cleanup
+                EditorUtility.ClearProgressBar();
+                EditorApplication.update -= updateAction;
+
+                if (www.result == UnityWebRequest.Result.Success)
+                {
+                    ProcessDownload(www.downloadHandler.data, targetPath);
+                }
+                else
+                {
+                    EditorUtility.DisplayDialog("Download Failed", $"Error: {www.error}", "OK");
+                }
+            
+                www.Dispose();
+            };
+
+            EditorApplication.update += updateAction;
+        }
+
+        private static void ProcessDownload(byte[] data, string targetFolder)
+        {
+            try 
+            {
+                if (!Directory.Exists(targetFolder)) Directory.CreateDirectory(targetFolder);
+            
+                string tempPath = Path.Combine(Application.temporaryCachePath, "csp_binaries.tgz");
+                File.WriteAllBytes(tempPath, data);
+
+                Debug.Log($"[MAGNOPUS] Extracting to {targetFolder}...");
+            
+                // Uses system 'tar' (Available on Win 10+, macOS, Linux)
+                System.Diagnostics.ProcessStartInfo startInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "tar",
+                    Arguments = $"-xf \"{tempPath}\" -C \"{targetFolder}\"",
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+
+                using (var process = System.Diagnostics.Process.Start(startInfo))
+                {
+                    process.WaitForExit();
+                }
+
+                File.Delete(tempPath);
+                AssetDatabase.Refresh();
+                EditorUtility.DisplayDialog("Success", "CSP Binaries installed in Assets/Plugins/CSP/Internal.", "OK");
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"[MAGNOPUS] Extraction failed: {e.Message}");
+            }
+        }
+
+        [Serializable]
+        private class DistributionMetadata
+        {
+            public string version;
+            public string tag;
+            public string downloadUrl;
+        }
+    }
+}

--- a/UnityProject/extra/Editor/CSPLibraryDownloader.cs
+++ b/UnityProject/extra/Editor/CSPLibraryDownloader.cs
@@ -201,9 +201,13 @@ namespace Plugins.Editor
                     {
                         File.Delete(tempPath);
                     }
-                    catch
+                    catch (DirectoryNotFoundException)
                     {
-                         /* Ignore cleanup errors in finally block */
+                        // don't care
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogException(e);
                     }
                 }
             }

--- a/UnityProject/extra/Editor/ConnectedSpacesPlatform.Editor.asmdef
+++ b/UnityProject/extra/Editor/ConnectedSpacesPlatform.Editor.asmdef
@@ -1,7 +1,9 @@
 {
-    "name": "NativePluginBuildProcessor",
+    "name": "ConnectedSpacesPlatform.Editor",
     "rootNamespace": "",
-    "references": [],
+    "references": [
+      "ConnectedSpacesPlatform.Unity.Core"
+    ],
     "includePlatforms": [
         "Editor"
     ],

--- a/UnityProject/extra/package.json.template
+++ b/UnityProject/extra/package.json.template
@@ -1,9 +1,13 @@
 {
-  "name": "com.magnopus.csp",
+  "name": "@magnopus-opensource/com.magnopus.csp.unity",
   "version": "VERSION_PLACEHOLDER",
   "displayName": "Connected Spaces Platform",
-  "description": "C# Wrapper for the Connected Spaces Platform (CSP).",
-  "unity": "2021.3",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "description": "C# Wrapper for the Connected Spaces Platform (CSP) for Unity.",
+  "unity": "6000.0",
+  "unityRelease": "70f1",
   "author": {
     "name": "Magnopus"
   },

--- a/UnityProject/extra/package.json.template
+++ b/UnityProject/extra/package.json.template
@@ -1,5 +1,5 @@
 {
-  "name": "@magnopus-opensource/com.magnopus.csp.unity",
+  "name": "com.magnopus.csp.unity",
   "version": "VERSION_PLACEHOLDER",
   "displayName": "Connected Spaces Platform",
   "publishConfig": {

--- a/UnityProject/extra/package.json.template
+++ b/UnityProject/extra/package.json.template
@@ -1,0 +1,11 @@
+{
+  "name": "com.magnopus.csp",
+  "version": "VERSION_PLACEHOLDER",
+  "displayName": "Connected Spaces Platform",
+  "description": "C# Wrapper for the Connected Spaces Platform (CSP).",
+  "unity": "2021.3",
+  "author": {
+    "name": "Magnopus"
+  },
+  "dependencies": {}
+}

--- a/Utilities/CI/assemble_dotnet.sh
+++ b/Utilities/CI/assemble_dotnet.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+mkdir -p DotNet/libs/Android/arm64-v8a
+mkdir -p DotNet/libs/iOS
+mkdir -p DotNet/libs/macOS
+mkdir -p DotNet/libs/Windows/x86_64
+mkdir -p DotNet/include
+
+find artifacts/android-* -name "*.so" -exec cp {} DotNet/libs/Android/arm64-v8a/ \; || true
+find artifacts/iOS-* -name "*.a" -exec cp {} DotNet/libs/iOS/ \; || true
+find artifacts/desktop-windows-* -name "*.dll" -exec cp {} DotNet/libs/Windows/x86_64/ \; || true
+find artifacts/desktop-macos-* -name "*.dylib" -exec cp -R {} DotNet/libs/macOS/ \; || true
+
+INCLUDE_DIR=$(find artifacts -type d -name "include" | head -n 1 || true)
+if [ -n "$INCLUDE_DIR" ]; then cp -R "$INCLUDE_DIR"/* DotNet/include; fi

--- a/Utilities/CI/assemble_unity.sh
+++ b/Utilities/CI/assemble_unity.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e # Exit immediately if a command fails
+
+VERSION=$1
+RELEASE_TAG=$2
+GITHUB_REPO=$3
+
+mkdir -p UnityPackage/Plugins/Android/libs/arm64-v8a
+mkdir -p UnityPackage/Plugins/iOS
+mkdir -p UnityPackage/Plugins/macOS
+mkdir -p UnityPackage/Plugins/Windows/x86_64
+mkdir -p UnityPackage/Runtime
+mkdir -p UnityPackage/Editor
+
+# Copy Native Binaries (Heavy)
+find artifacts/android-* -name "*.so" -exec cp {} UnityPackage/Plugins/Android/libs/arm64-v8a/ \; || true
+find artifacts/iOS-* -name "*.a" -exec cp {} UnityPackage/Plugins/iOS/ \; || true
+find artifacts/desktop-windows-*-Unity -name "*.dll" -exec cp {} UnityPackage/Plugins/Windows/x86_64/ \; || true
+find artifacts/desktop-macos-*-Unity -name "*.dylib" -exec cp -R {} UnityPackage/Plugins/macOS/ \; || true
+
+# Copy Source/Metadata
+INCLUDE_DIR=$(find artifacts -type d -name "include" | head -n 1 || true)
+if [ -n "$INCLUDE_DIR" ]; then cp -R "$INCLUDE_DIR"/* UnityPackage/Runtime; fi
+cp -r UnityProject/extra/Editor/* UnityPackage/Editor/ || true
+cp UnityProject/extra/ConnectedSpacesPlatform.Unity.Core.asmdef UnityPackage/Runtime/ || true
+
+# Generate Package Metadata
+CLEAN_VERSION="${VERSION#v}"
+cmake -D "TEMPLATE=UnityProject/extra/package.json.template" \
+      -D "OUTPUT=UnityPackage/package.json" \
+      -D "VERSION=$CLEAN_VERSION" \
+      -P cmake/GeneratePackageJson.cmake
+
+echo '{
+  "version": "'$VERSION'",
+  "downloadUrl": "https://github.com/'$GITHUB_REPO'/releases/download/'$RELEASE_TAG'/com.magnopus.csp.unity-'$VERSION'.tgz"
+}' > UnityPackage/package-dist.json

--- a/Utilities/CI/generate_unity_meta.py
+++ b/Utilities/CI/generate_unity_meta.py
@@ -1,34 +1,57 @@
-import os, uuid
+import hashlib
+from pathlib import Path
 
-def generate_meta(target_path, is_dir, is_cs):
-    meta_path = target_path + '.meta'
+def get_guid(name_string):
+    # Deterministic: same path = same GUID
+    return hashlib.md5(name_string.encode('utf-8')).hexdigest()
+
+def generate_meta(file_path: Path, package_root: Path, is_directory: bool):
+    # Append .meta without stripping the original extension
+    meta_path = file_path.parent / (file_path.name + '.meta')
 
     # Skip if a .meta file already exists
-    if os.path.exists(meta_path):
+    if meta_path.exists():
         return
 
-    guid = uuid.uuid4().hex
-    content = f"fileFormatVersion: 2\nguid: {guid}\n"
 
-    if is_dir:
-        content += "folderAsset: yes\nDefaultImporter:\n  externalObjects: {}\n  userData: \n  assetBundleName: \n  assetBundleVariant: \n"
-    elif is_cs:
-        content += "MonoImporter:\n  externalObjects: {}\n  serializedVersion: 2\n  iconMap: {}\n  executionOrder: 0\n"
+    # Everything is relative to the root (forced to forward slashes)
+    rel_path_str = file_path.relative_to(package_root).as_posix()
+    guid = get_guid(rel_path_str)
+
+    if is_directory:
+        body = ("folderAsset: yes\n"
+                "DefaultImporter:\n"
+                "  externalObjects: {}\n"
+                "  userData: \n"
+                "  assetBundleName: \n"
+                "  assetBundleVariant: ")
+    elif file_path.suffix == '.cs':
+        body = ("MonoImporter:\n"
+                "  externalObjects: {}\n"
+                "  serializedVersion: 2\n"
+                "  iconMap: {}\n"
+                "  executionOrder: 0")
     else:
-        content += "DefaultImporter:\n  externalObjects: {}\n  userData: \n  assetBundleName: \n  assetBundleVariant: \n"
-
-    with open(meta_path, 'w', encoding='utf-8') as f:
+        body = ("DefaultImporter:\n"
+                "  externalObjects: {}\n"
+                "  userData: \n"
+                "  assetBundleName: \n"
+                "  assetBundleVariant: ")
+    
+    content = f"fileFormatVersion: 2\nguid: {guid}\n{body}\n"
+    
+    # Note: forcing newline format to make sure this persists across platforms
+    with meta_path.open("w", encoding="utf-8", newline="\n") as f:
         f.write(content)
 
-package_root = 'UnityPackage'
 
-for root, dirs, files in os.walk(package_root):
-    for dir_name in dirs:
-        if dir_name.startswith('.'): continue
-        target = os.path.join(root, dir_name)
-        generate_meta(target, is_dir=True, is_cs=False)
+package_dir = Path('UnityPackage').resolve()
 
-    for file_name in files:
-        if file_name.endswith('.meta') or file_name.startswith('.'): continue
-        target = os.path.join(root, file_name)
-        generate_meta(target, is_dir=False, is_cs=file_name.endswith('.cs'))
+# Generate .meta for everything inside the root directory
+for item in package_dir.rglob('*'):
+    # Skip existing metas, hidden files, and the root itself
+    if item.suffix == '.meta' or item.name.startswith('.'):
+        continue
+
+    is_dir = item.is_dir()
+    generate_meta(item, package_dir, is_dir)

--- a/Utilities/CI/generate_unity_meta.py
+++ b/Utilities/CI/generate_unity_meta.py
@@ -1,0 +1,34 @@
+import os, uuid
+
+def generate_meta(target_path, is_dir, is_cs):
+    meta_path = target_path + '.meta'
+
+    # Skip if a .meta file already exists
+    if os.path.exists(meta_path):
+        return
+
+    guid = uuid.uuid4().hex
+    content = f"fileFormatVersion: 2\nguid: {guid}\n"
+
+    if is_dir:
+        content += "folderAsset: yes\nDefaultImporter:\n  externalObjects: {}\n  userData: \n  assetBundleName: \n  assetBundleVariant: \n"
+    elif is_cs:
+        content += "MonoImporter:\n  externalObjects: {}\n  serializedVersion: 2\n  iconMap: {}\n  executionOrder: 0\n"
+    else:
+        content += "DefaultImporter:\n  externalObjects: {}\n  userData: \n  assetBundleName: \n  assetBundleVariant: \n"
+
+    with open(meta_path, 'w', encoding='utf-8') as f:
+        f.write(content)
+
+package_root = 'UnityPackage'
+
+for root, dirs, files in os.walk(package_root):
+    for dir_name in dirs:
+        if dir_name.startswith('.'): continue
+        target = os.path.join(root, dir_name)
+        generate_meta(target, is_dir=True, is_cs=False)
+
+    for file_name in files:
+        if file_name.endswith('.meta') or file_name.startswith('.'): continue
+        target = os.path.join(root, file_name)
+        generate_meta(target, is_dir=False, is_cs=file_name.endswith('.cs'))

--- a/Utilities/CI/publish_branch.sh
+++ b/Utilities/CI/publish_branch.sh
@@ -16,7 +16,7 @@ set -e
 # 5. Restores the staged source files, commits (if changes exist), tags, and pushes.
 #
 # USAGE:
-# bash Utilities/CI/publish_branch.sh <SOURCE_DIR> <TARGET_BRANCH> <VERSION> [EXCLUDE_DIR]
+# bash publish_branch.sh <SOURCE_DIR> <TARGET_BRANCH> <VERSION> [EXCLUDE_DIR] [--dry-run]
 # Example: bash Utilities/CI/publish_branch.sh "DotNet" "release/dotnet" "v0.0.2" "libs"
 # ==============================================================================
 
@@ -24,31 +24,38 @@ SOURCE_DIR=$1
 TARGET_BRANCH=$2
 VERSION=$3
 EXCLUDE_DIR=$4 
+DRY_RUN=false
+
+# Check if the last argument is --dry-run
+for arg in "$@"; do
+    if [ "$arg" == "--dry-run" ]; then
+        DRY_RUN=true
+        echo "DRY RUN ENABLED: No changes will be pushed or tagged."
+    fi
+done
 
 git config user.name "github-actions[bot]"
 git config user.email "github-actions[bot]@users.noreply.github.com"
 
 echo "Staging $SOURCE_DIR to temporary directory..."
 mkdir -p ../dist-temp
-cp -r $SOURCE_DIR/* ../dist-temp/
+cp -r "$SOURCE_DIR"/* ../dist-temp/
 
 # Remove the heavy binaries before committing to Git
-if [ -n "$EXCLUDE_DIR" ]; then 
+if [ -n "$EXCLUDE_DIR" ] && [ -d "../dist-temp/$EXCLUDE_DIR" ]; then 
     echo "Excluding $EXCLUDE_DIR from Git..."
-    rm -rf ../dist-temp/$EXCLUDE_DIR 
+    rm -rf "../dist-temp/$EXCLUDE_DIR" 
 fi
 
 echo "Switching to $TARGET_BRANCH..."
 # Use ls-remote to check if the branch actually exists on the remote repository
-if git ls-remote --exit-code --heads origin $TARGET_BRANCH >/dev/null 2>&1; then
-    echo "Branch $TARGET_BRANCH exists on remote. Syncing to remote tip..."
+if git ls-remote --exit-code --heads origin "$TARGET_BRANCH" >/dev/null 2>&1; then
     # Fetch the exact remote tip into FETCH_HEAD
-    git fetch origin $TARGET_BRANCH
+    git fetch origin "$TARGET_BRANCH"
     # Force the local branch to perfectly match the remote tip
-    git checkout -B $TARGET_BRANCH FETCH_HEAD
+    git checkout -B "$TARGET_BRANCH" FETCH_HEAD
 else
-    echo "Branch $TARGET_BRANCH does not exist. Creating orphan branch..."
-    git checkout --orphan $TARGET_BRANCH
+    git checkout --orphan "$TARGET_BRANCH"
 fi
 
 echo "Cleaning working directory..."
@@ -67,12 +74,26 @@ if git diff --staged --quiet; then
     echo "No changes detected for $TARGET_BRANCH. Working tree is identical."
     echo "Skipping commit, but proceeding to tag to maintain lockstep versioning."
 else
-    git commit -m "Release $VERSION"
-    git push origin $TARGET_BRANCH
+    if [ "$DRY_RUN" = true ]; then
+        echo "[DRY RUN] Would commit: 'Release $VERSION'"
+        echo "[DRY RUN] Would push to: origin $TARGET_BRANCH"
+    else
+        git commit -m "Release $VERSION"
+        git push origin "$TARGET_BRANCH"
+    fi
 fi
 
 # Note: Extracts just the 'dotnet' part from 'release/dotnet' for the tag
 # ALWAYS tag the branch to ensure Unity and DotNet stay in lockstep
 TAG_NAME="${TARGET_BRANCH##*/}/$VERSION" 
-git tag -f "$TAG_NAME"
-git push -f origin "$TAG_NAME"
+
+if [ "$DRY_RUN" = true ]; then
+    echo "[DRY RUN] Would tag: $TAG_NAME"
+    echo "[DRY RUN] Would push tag to origin"
+else
+    git tag -f "$TAG_NAME"
+    git push -f origin "$TAG_NAME"
+fi
+
+echo "Process complete."
+if [ "$DRY_RUN" = true ]; then echo "Note: This was a dry run. Remote was not modified."; fi

--- a/Utilities/CI/publish_branch.sh
+++ b/Utilities/CI/publish_branch.sh
@@ -13,11 +13,11 @@ set -e
 # 2. Strips out heavy native binaries (like .dll or .so files) to prevent Git bloat.
 # 3. Securely syncs with the remote branch (or creates an orphan if new).
 # 4. Clears the working directory (preserving the .git folder).
-# 5. Restores the staged source files, commits, tags, and pushes.
+# 5. Restores the staged source files, commits (if changes exist), tags, and pushes.
 #
 # USAGE:
-# ./Utilities/CI/publish_branch.sh <SOURCE_DIR> <TARGET_BRANCH> <VERSION> [EXCLUDE_DIR]
-# Example: ./Utilities/CI/publish_branch.sh "DotNet" "release/dotnet" "v1.0.0" "libs"
+# bash Utilities/CI/publish_branch.sh <SOURCE_DIR> <TARGET_BRANCH> <VERSION> [EXCLUDE_DIR]
+# Example: bash Utilities/CI/publish_branch.sh "DotNet" "release/dotnet" "v0.0.2" "libs"
 # ==============================================================================
 
 SOURCE_DIR=$1
@@ -59,12 +59,20 @@ ls -A | grep -v "^.git$" | xargs rm -rf
 echo "Restoring source files..."
 mv ../dist-temp/* .
 
-echo "Committing and pushing..."
+echo "Checking for changes to commit..."
 git add .
-git commit -m "Release $VERSION"
-git push origin $TARGET_BRANCH
+
+# Safely check if the staging area has any actual changes
+if git diff --staged --quiet; then
+    echo "No changes detected for $TARGET_BRANCH. Working tree is identical."
+    echo "Skipping commit, but proceeding to tag to maintain lockstep versioning."
+else
+    git commit -m "Release $VERSION"
+    git push origin $TARGET_BRANCH
+fi
 
 # Note: Extracts just the 'dotnet' part from 'release/dotnet' for the tag
+# ALWAYS tag the branch to ensure Unity and DotNet stay in lockstep
 TAG_NAME="${TARGET_BRANCH##*/}/$VERSION" 
 git tag -f "$TAG_NAME"
-git push origin "$TAG_NAME"
+git push -f origin "$TAG_NAME"

--- a/Utilities/CI/publish_branch.sh
+++ b/Utilities/CI/publish_branch.sh
@@ -11,7 +11,7 @@ set -e
 # HOW IT WORKS:
 # 1. Stages the target directory in a temporary folder outside the workspace.
 # 2. Strips out heavy native binaries (like .dll or .so files) to prevent Git bloat.
-# 3. Checks out an orphan/clean target branch.
+# 3. Securely syncs with the remote branch (or creates an orphan if new).
 # 4. Clears the working directory (preserving the .git folder).
 # 5. Restores the staged source files, commits, tags, and pushes.
 #
@@ -39,8 +39,17 @@ if [ -n "$EXCLUDE_DIR" ]; then
 fi
 
 echo "Switching to $TARGET_BRANCH..."
-git fetch origin $TARGET_BRANCH || true
-git checkout $TARGET_BRANCH || git checkout --orphan $TARGET_BRANCH
+# Use ls-remote to check if the branch actually exists on the remote repository
+if git ls-remote --exit-code --heads origin $TARGET_BRANCH >/dev/null 2>&1; then
+    echo "Branch $TARGET_BRANCH exists on remote. Syncing to remote tip..."
+    # Fetch the exact remote tip into FETCH_HEAD
+    git fetch origin $TARGET_BRANCH
+    # Force the local branch to perfectly match the remote tip
+    git checkout -B $TARGET_BRANCH FETCH_HEAD
+else
+    echo "Branch $TARGET_BRANCH does not exist. Creating orphan branch..."
+    git checkout --orphan $TARGET_BRANCH
+fi
 
 echo "Cleaning working directory..."
 git rm -rf . --ignore-unmatch > /dev/null

--- a/Utilities/CI/publish_branch.sh
+++ b/Utilities/CI/publish_branch.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -e
+
+# ==============================================================================
+# publish_branch.sh
+#
+# PURPOSE:
+# This script safely pushes a specific directory of source code to a target 
+# release branch (e.g., release/dotnet or release/unity). 
+# 
+# HOW IT WORKS:
+# 1. Stages the target directory in a temporary folder outside the workspace.
+# 2. Strips out heavy native binaries (like .dll or .so files) to prevent Git bloat.
+# 3. Checks out an orphan/clean target branch.
+# 4. Clears the working directory (preserving the .git folder).
+# 5. Restores the staged source files, commits, tags, and pushes.
+#
+# USAGE:
+# ./Utilities/CI/publish_branch.sh <SOURCE_DIR> <TARGET_BRANCH> <VERSION> [EXCLUDE_DIR]
+# Example: ./Utilities/CI/publish_branch.sh "DotNet" "release/dotnet" "v1.0.0" "libs"
+# ==============================================================================
+
+SOURCE_DIR=$1
+TARGET_BRANCH=$2
+VERSION=$3
+EXCLUDE_DIR=$4 
+
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+
+echo "Staging $SOURCE_DIR to temporary directory..."
+mkdir -p ../dist-temp
+cp -r $SOURCE_DIR/* ../dist-temp/
+
+# Remove the heavy binaries before committing to Git
+if [ -n "$EXCLUDE_DIR" ]; then 
+    echo "Excluding $EXCLUDE_DIR from Git..."
+    rm -rf ../dist-temp/$EXCLUDE_DIR 
+fi
+
+echo "Switching to $TARGET_BRANCH..."
+git fetch origin $TARGET_BRANCH || true
+git checkout $TARGET_BRANCH || git checkout --orphan $TARGET_BRANCH
+
+echo "Cleaning working directory..."
+git rm -rf . --ignore-unmatch > /dev/null
+# Delete all files/folders EXCEPT .git to avoid "Directory not empty" errors
+ls -A | grep -v "^.git$" | xargs rm -rf
+
+echo "Restoring source files..."
+mv ../dist-temp/* .
+
+echo "Committing and pushing..."
+git add .
+git commit -m "Release $VERSION"
+git push origin $TARGET_BRANCH
+
+# Note: Extracts just the 'dotnet' part from 'release/dotnet' for the tag
+TAG_NAME="${TARGET_BRANCH##*/}/$VERSION" 
+git tag -f "$TAG_NAME"
+git push origin "$TAG_NAME"

--- a/cmake/GeneratePackageJson.cmake
+++ b/cmake/GeneratePackageJson.cmake
@@ -1,0 +1,11 @@
+# cmake/GeneratePackageJson.cmake
+# Usage: cmake -D TEMPLATE=... -D OUTPUT=... -D VERSION=... -P cmake/GeneratePackageJson.cmake
+
+# Read the template
+file(READ "${TEMPLATE}" CONTENT)
+
+# Replace the placeholder
+string(REPLACE "VERSION_PLACEHOLDER" "${VERSION}" UPDATED_CONTENT "${CONTENT}")
+
+# Write the final package.json
+file(WRITE "${OUTPUT}" "${UPDATED_CONTENT}")

--- a/cmake/PatchPInvoke.cmake
+++ b/cmake/PatchPInvoke.cmake
@@ -1,0 +1,7 @@
+# This script is called by CMake -P to perform cross-platform text replacement
+file(READ "${FILE_TO_PATCH}" CONTENT)
+
+# Replace the quoted placeholder with the unquoted variable name
+string(REPLACE "${OLD_STR}" "${NEW_STR}" REPLACED_CONTENT "${CONTENT}")
+
+file(WRITE "${FILE_TO_PATCH}" "${REPLACED_CONTENT}")

--- a/interface/main.i
+++ b/interface/main.i
@@ -3,6 +3,23 @@
  * The module name here should match the standard base name of the .dll */
 %module(directors="1") ConnectedSpacesPlatform
 
+#ifdef SWIGCSHARP
+/* * LibName Resolver:
+ * This constant determines the native library name used by DllImport.
+ * - In Unity (iOS/visionOS): Uses "__Internal" for static linking.
+ * - In Unity (Editor/Android/Desktop) & Pure .NET: Uses "ConnectedSpacesPlatformDotNet".
+ * This allows the same C# source to be used across all supported platforms.
+ */
+%pragma(csharp) imclasscode=%{
+  public const string LibName = 
+#if (UNITY_IOS || UNITY_VISIONOS) && !UNITY_EDITOR
+    "__Internal";
+#else
+    "ConnectedSpacesPlatformDotNet";
+#endif
+%}
+#endif
+
 /* Enable namespaces flags to try and keep original namespaces hierarchy */
 %feature("nspace", 1);
 

--- a/interface/main.i
+++ b/interface/main.i
@@ -9,6 +9,17 @@
  * - In Unity (iOS/visionOS): Uses "__Internal" for static linking.
  * - In Unity (Editor/Android/Desktop) & Pure .NET: Uses "ConnectedSpacesPlatformDotNet".
  * This allows the same C# source to be used across all supported platforms.
+ *
+ * We need this because in Unity for example you can choose a target platform before making a build from the Editor,
+ * so the code needs to adapt once building instead of having the hardcoded value for all target platforms.
+ * This justifies the need for LibName to be a variable interpreted for the chosen target platform at compile time.
+ * Similarly, for future proofing this, developers can change the logic of this #if block if they have 
+ * additional rules to treat the output build with static or dynamic linking (aka __Internal vs 
+ * ConnectedSpacesPlatformDotNet dll name).
+ *
+ * Specifically this is required because IL2CPP uses different linkage on iOS (static lib) and e.g. Android (shared) 
+ * so the PInvoke attributes have to specify a different source library (See the example 
+ * here: https://docs.unity3d.com/6000.3/Documentation/Manual/plug-ins-native.html)
  */
 %pragma(csharp) imclasscode=%{
   public const string LibName = 


### PR DESCRIPTION
Ticket: https://magnopus.atlassian.net/browse/OPE-3175

This PR updates the workflows to:

1. Properly filter artifacts between Unity and dotnet, making the workflows exclusive and independent.

2. Fix linking using a variable instead of hard coding the dllname used by dllimport (needed as __Internal for iOS and visionOS due to the static linking, but as ConnectedSpacesPlatformDotNet for platforms that need dynamic linking).

3. Produce a tarball for Unity (.tgz instead of .zip), which is more standard for Unity import flow.

4. Update release pipeline to use release branch (where source codes generated by SWIG are pushed to and versioned) + Github release page (where the versioned libraries and binaries produced by SWIG are published to, versioned).

5. Generate the .meta files for the source code pushed to the release branch of Unity, because once Unity pulls the source codes it stores them into PackageCache, which is immutable. This means that Unity won't be able to generate the .meta required to compile the scripts, so we produce them via CI.


**Testing**
I tested the whole workflow by using a temporary push trigger for this branch, which triggered the make-release.yml flow. As a result, this flow:

1. Produced the libraries (.tgz for Unity and .zip for DotNet, publishing them onto [this Github release page](https://github.com/magnopus-opensource/connected-spaces-platform-unity/releases/tag/test-0.0.1-23)).
2. Pushed the related versioned code generated by SWIG into the [release/unity](https://github.com/magnopus-opensource/connected-spaces-platform-unity/tree/release/unity) and [release/dotnet](https://github.com/magnopus-opensource/connected-spaces-platform-unity/tree/release/dotnet) branches.

I then tested the import into Unity, which I detailed into our internal documenation.

Updated docs: https://magnopus.atlassian.net/wiki/spaces/OL/pages/4191060014/CSP+Unity+interop+Release+process