### PR TITLE
[OPE-3175] Resolve boolean stringification bug in release workflows

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -53,7 +53,7 @@ jobs:
     with:
       version: ${{ needs.prep-release.outputs.version }}
       releaseTag: ${{ needs.prep-release.outputs.release_tag }}
-      is_official_release: ${{ github.event.inputs.is_official_release == true || false }}
+      is_official_release: ${{ inputs.is_official_release == true || inputs.is_official_release == 'true' }}
 
   # Run DotNet Packaging
   package-dotnet:
@@ -64,7 +64,7 @@ jobs:
     with:
       version: ${{ needs.prep-release.outputs.version }}
       releaseTag: ${{ needs.prep-release.outputs.release_tag }}
-      is_official_release: ${{ github.event.inputs.is_official_release == true || false }}
+      is_official_release: ${{ inputs.is_official_release == true || inputs.is_official_release == 'true' }}
 
   # Create the Release
   publish-release:


### PR DESCRIPTION
When triggering the workflow from Git actions the boolean is_official_release seems to be treated as a string literal rather than a bool. This caused it to evaluate as false even when checked from the action ui. This commit fixes that by comparing it both as a bool and as a string.