### PR TITLE
Ability to make integrated builds from CSP branches, not just prebuilt releases.

### DIFF
--- a/.github/actions/build-csp-macos/action.yml
+++ b/.github/actions/build-csp-macos/action.yml
@@ -1,0 +1,87 @@
+name: Build CSP macOS
+description: Composite action that checks out, installs dependencies, and builds CSP as a shared library on macOS in the requested build type (Debug or Release). Outputs installs to "CSP/install" dir, creating an `include`, `bin` and `lib` directory. Targets Apple Silicon (arm64) via the upstream osx_arm Conan profile. To run this, you need to have run actions/checkout in the consuming workflow, with a fetch-depth of 0 such that git tags are available.
+
+inputs:
+  csp_branch:
+    description: CSP branch to build, defaults to main.
+    required: false
+    default: 'main'
+  build_type:
+    description: Debug or Release
+    required: true
+    default: 'Debug'
+
+runs:
+  using: composite
+  steps:
+
+    - name: Checkout connected-spaces-platform
+      uses: actions/checkout@v4
+      with:
+        repository: magnopus-opensource/connected-spaces-platform
+        path: CSP
+        ref: ${{inputs.csp_branch}}
+        fetch-depth: 0 # Required for git describe to find version tags, which we need for CSP_VERSION
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+        cache: pip
+
+    - name: Install Conan
+      shell: bash
+      run: pip install "conan==2.27.0"
+
+    # Split restore/save: the save step is gated on `success()` so an interrupted or failed
+    # `conan install` cannot poison the cache with a partial `~/.conan2/p`.
+    - name: Cache Conan packages (restore)
+      id: conan-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.conan2/p # Conan 2 package cache
+        key: conan-macos-${{ inputs.build_type }}-${{ hashFiles('CSP/conanfile.py', 'CSP/profiles/host/osx_arm') }}
+        restore-keys: conan-macos-${{ inputs.build_type }}- # Get the most recent cache even if hash doesn't exactly match, as a fallback.
+
+    - name: Detect Conan build profile
+      shell: bash
+      run: conan profile detect --force
+
+    - name: Conan install
+      shell: bash
+      working-directory: "./CSP"
+      run: >
+        conan install .
+        --profile:host=profiles/host/osx_arm
+        -s build_type=${{inputs.build_type}}
+        --build=missing
+
+    - name: Cache Conan packages (save)
+      if: success() && steps.conan-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ~/.conan2/p
+        key: conan-macos-${{ inputs.build_type }}-${{ hashFiles('CSP/conanfile.py', 'CSP/profiles/host/osx_arm') }}
+
+    - name: Install wrapper generator dependencies
+      shell: bash
+      run: pip install chevron==0.14.0 jinja2==3.1.2
+
+    # Run the legacy wrapper generator — its output is included directly in CSPFoundation.cpp. Should go away eventually
+    - name: Run wrapper generator
+      shell: bash
+      run: python CSP/Tools/WrapperGenerator/WrapperGenerator.py
+
+    - name: Configure
+      shell: bash
+      working-directory: "./CSP"
+      run: cmake --preset ${{ inputs.build_type == 'Debug' && 'debug-shared' || 'release-shared' }}
+
+    - name: Build
+      shell: bash
+      working-directory: "./CSP"
+      run: cmake --build --preset ${{ inputs.build_type == 'Debug' && 'debug-shared' || 'release-shared' }} --parallel
+
+    - name: Install
+      shell: bash
+      working-directory: "./CSP"
+      run: cmake --install build/${{inputs.build_type}} --prefix install

--- a/.github/actions/build-csp-macos/action.yml
+++ b/.github/actions/build-csp-macos/action.yml
@@ -84,7 +84,7 @@ runs:
     - name: Build
       shell: bash
       working-directory: "./CSP"
-      run: cmake --build --preset ${{ inputs.build_type == 'Debug' && 'debug-shared' || 'release-shared' }} --parallel
+      run: cmake --build --preset ${{ inputs.build_type == 'Debug' && 'debug-shared' || 'release-shared' }} --parallel 2
 
     - name: Install
       shell: bash

--- a/.github/actions/build-csp-macos/action.yml
+++ b/.github/actions/build-csp-macos/action.yml
@@ -49,6 +49,11 @@ runs:
     - name: Conan install
       shell: bash
       working-directory: "./CSP"
+      env:
+        # CMake 4 dropped support for cmake_minimum_required(VERSION <3.5), which
+        # some older transitive Conan recipes (e.g. asyncplusplus/1.2) still
+        # declare. We don't maintain pre-3.5 CMake compatibility.
+        CMAKE_POLICY_VERSION_MINIMUM: '3.5'
       run: >
         conan install .
         --profile:host=profiles/host/osx_arm

--- a/.github/actions/build-csp-windows/action.yml
+++ b/.github/actions/build-csp-windows/action.yml
@@ -54,6 +54,11 @@ runs:
     - name: Conan install
       shell: pwsh
       working-directory: "./CSP"
+      env:
+        # CMake 4 dropped support for cmake_minimum_required(VERSION <3.5), which
+        # some older transitive Conan recipes (e.g. asyncplusplus/1.2) still
+        # declare. We don't maintain pre-3.5 CMake compatibility.
+        CMAKE_POLICY_VERSION_MINIMUM: '3.5'
       run: >
         conan install .
         --profile:host=profiles/host/windows_ninja

--- a/.github/actions/build-csp-windows/action.yml
+++ b/.github/actions/build-csp-windows/action.yml
@@ -89,7 +89,7 @@ runs:
     - name: Build
       shell: pwsh
       working-directory: "./CSP"
-      run: cmake --build --preset ${{ inputs.build_type == 'Debug' && 'debug-shared' || 'release-shared' }} --parallel
+      run: cmake --build --preset ${{ inputs.build_type == 'Debug' && 'debug-shared' || 'release-shared' }} --parallel 2
       
     - name: Install
       shell: pwsh

--- a/.github/actions/build-csp-windows/action.yml
+++ b/.github/actions/build-csp-windows/action.yml
@@ -1,0 +1,92 @@
+name: Build CSP Windows
+description: Composite action that checks out, installs dependencies, and builds CSP as a shared library on Windows in the requested build type (Debug or Release). Outputs installs to "CSP/install" dir, creating an `include`, `bin` and `lib` directory. Extensible to take further configuration inputs if we ever need more than just Shared. To run this, you need to have run actions/checkout in the consuming workflow, with a fetch-depth of 0 such that git tags are available.
+
+inputs:
+  csp_branch: 
+    description: CSP branch to build, defaults to main.
+    required: false
+    default: 'main'
+  build_type:
+    description: Debug or Release
+    required: true
+    default : 'Debug'
+
+runs:
+  using: composite
+  steps:
+
+    - name: Checkout connected-spaces-platform
+      uses: actions/checkout@v4
+      with:
+        repository: magnopus-opensource/connected-spaces-platform
+        path: CSP
+        ref: ${{inputs.csp_branch}}
+        fetch-depth: 0 # Required for git describe to find version tags, which we need for CSP_VERSION
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+        cache: pip
+
+    # We need cl.exe on the path.
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: x64
+
+    - name: Install Conan
+      shell: pwsh
+      run: pip install "conan==2.27.0"
+
+    # Split restore/save: the save step is gated on `success()` so an interrupted or failed
+    # `conan install` cannot poison the cache with a partial `~/.conan2/p`.
+    - name: Cache Conan packages (restore)
+      id: conan-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.conan2/p # Conan 2 package cache
+        key: conan-windows-${{ inputs.build_type }}-${{ hashFiles('CSP/conanfile.py', 'CSP/profiles/host/windows_ninja') }}
+        restore-keys: conan-windows-${{ inputs.build_type }}- # Get the most recent cache even if hash doesn't exactly match, as a fallback.
+
+    - name: Detect Conan build profile
+      shell: pwsh
+      run: conan profile detect --force
+
+    - name: Conan install
+      shell: pwsh
+      working-directory: "./CSP"
+      run: >
+        conan install .
+        --profile:host=profiles/host/windows_ninja
+        -s build_type=${{inputs.build_type}}
+        --build=missing
+
+    - name: Cache Conan packages (save)
+      if: success() && steps.conan-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ~/.conan2/p
+        key: conan-windows-${{ inputs.build_type }}-${{ hashFiles('CSP/conanfile.py', 'CSP/profiles/host/windows_ninja') }}
+
+    - name: Install wrapper generator dependencies
+      shell: pwsh
+      run: pip install chevron==0.14.0 jinja2==3.1.2
+
+    # Run the legacy wrapper generator — its output is included directly in CSPFoundation.cpp. Should go away eventually
+    - name: Run wrapper generator
+      shell: pwsh
+      run: python CSP/Tools/WrapperGenerator/WrapperGenerator.py
+
+    - name: Configure
+      shell: pwsh
+      working-directory: "./CSP"
+      run: cmake --preset ${{ inputs.build_type == 'Debug' && 'debug-shared' || 'release-shared' }}
+
+    - name: Build
+      shell: pwsh
+      working-directory: "./CSP"
+      run: cmake --build --preset ${{ inputs.build_type == 'Debug' && 'debug-shared' || 'release-shared' }} --parallel
+      
+    - name: Install
+      shell: pwsh
+      working-directory: "./CSP"
+      run: cmake --install build/${{inputs.build_type}} --prefix install

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -11,6 +11,11 @@ on:
         description: 'This parameter establishes whether SWIG should generate the additional bindings for supporting Unity applications (true) or just the code for supporting general purpose .NET C# applications (false). This is expected to be a JSON array: it is possible to produce both cases by passing [true, false].'
         required: false
         default: '[true, false]'
+      platform_matrix:
+        description: 'What platforms to run these checks on. Expected to be a JSON array ["windows-latest", "macos-latest"]'
+        type: string
+        required: false
+        default: '["windows-latest", "macos-latest"]'
       csp_branch: 
         description: 'If set, will build a specific version of CSP from a CSP branch using the new cmake build system, then run with that.'
         type: string
@@ -22,6 +27,10 @@ on:
         type: string
         required: false
         default: '[true, false]'
+      platform_matrix: # What platforms to run these checks on. Expected to be a JSON array ["windows-latest", "macos-latest"]
+        type: string
+        required: false
+        default: '["windows-latest", "macos-latest"]'
       csp_branch: # If set, will build a specific version of CSP from a CSP branch using the new cmake build system, then run with that.
         type: string
         required: false
@@ -39,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest]
+        os: ${{ fromJSON(inputs.platform_matrix || '["windows-latest", "macos-latest"]') }}
         build_type: [Debug, Release]
         # If an input is provided, parse it. Otherwise, default to building both.
         build_with_unity_extensions: ${{ fromJSON(inputs.unity_ext_matrix || '[true, false]') }}

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -11,12 +11,24 @@ on:
         description: 'This parameter establishes whether SWIG should generate the additional bindings for supporting Unity applications (true) or just the code for supporting general purpose .NET C# applications (false). This is expected to be a JSON array: it is possible to produce both cases by passing [true, false].'
         required: false
         default: '[true, false]'
+      csp_branch: 
+        description: 'If set, will build a specific version of CSP from a CSP branch using the new cmake build system, then run with that.'
+        type: string
+        required: false
+        default: ''
   workflow_call: # Allows other workflows to call this one and wait for its artifacts
     inputs:
       unity_ext_matrix:
         type: string
         required: false
         default: '[true, false]'
+      csp_branch: # If set, will build a specific version of CSP from a CSP branch using the new cmake build system, then run with that.
+        type: string
+        required: false
+        default: ''
+
+env:
+  BUILDING_FROM_BRANCH: ${{ inputs.csp_branch != '' }}
 
 jobs:
   build:
@@ -41,11 +53,29 @@ jobs:
         with:
           dotnet-version: '8.x'
 
+      - name: Build CSP
+        if: env.BUILDING_FROM_BRANCH == 'true' && runner.os == 'Windows'
+        uses: ./.github/actions/build-csp-windows
+        with:
+          csp_branch: ${{inputs.csp_branch}}
+          build_type: ${{ matrix.build_type }}
+
+      - name: Install CSP Consumer Dependencies (temp) # We shouldn't need to do this forever, the new CSP build system is just under development and we haven't properly expunged public symbols yet.
+        if: env.BUILDING_FROM_BRANCH == 'true' && runner.os == 'Windows'
+        run: |
+          pip install "conan==2.27.0"
+          conan install . --output-folder=build --build=missing -s build_type=${{ matrix.build_type }};
+
       - name: Configure
-        run: cmake -S . -B build -DENABLE_UNITY_EXTENSIONS=${{ matrix.build_with_unity_extensions && 'ON' || 'OFF' }}
+        run: > 
+          cmake -S . -B build 
+          -DENABLE_UNITY_EXTENSIONS=${{ matrix.build_with_unity_extensions && 'ON' || 'OFF' }}
+          ${{ env.BUILDING_FROM_BRANCH == 'true' && '-DLEGACY_BUILD_SYSTEM=Off' || '' }}
+          ${{ env.BUILDING_FROM_BRANCH == 'true' && format('-DCMAKE_PREFIX_PATH={0}/CSP/install', github.workspace) || '' }}
+          ${{ env.BUILDING_FROM_BRANCH == 'true' && '-DCMAKE_TOOLCHAIN_FILE="build/conan_toolchain.cmake"' || '' }}
 
       - name: Build
-        run: cmake --build build --config ${{ matrix.build_type }}
+        run: cmake --build build --config ${{ matrix.build_type }} 
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: ${{ runner.job_count }}
 

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -74,8 +74,9 @@ jobs:
           conan install . --output-folder=build --build=missing -s build_type=${{ matrix.build_type }};
 
       - name: Configure
-        run: > 
-          cmake -S . -B build 
+        run: >
+          cmake -S . -B build
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -DENABLE_UNITY_EXTENSIONS=${{ matrix.build_with_unity_extensions && 'ON' || 'OFF' }}
           ${{ env.BUILDING_FROM_BRANCH == 'true' && '-DLEGACY_BUILD_SYSTEM=Off' || '' }}
           ${{ env.BUILDING_FROM_BRANCH == 'true' && format('-DCMAKE_PREFIX_PATH={0}/CSP/install', github.workspace) || '' }}

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -53,15 +53,22 @@ jobs:
         with:
           dotnet-version: '8.x'
 
-      - name: Build CSP
+      - name: Build CSP (Windows)
         if: env.BUILDING_FROM_BRANCH == 'true' && runner.os == 'Windows'
         uses: ./.github/actions/build-csp-windows
         with:
           csp_branch: ${{inputs.csp_branch}}
           build_type: ${{ matrix.build_type }}
 
+      - name: Build CSP (macOS)
+        if: env.BUILDING_FROM_BRANCH == 'true' && runner.os == 'macOS'
+        uses: ./.github/actions/build-csp-macos
+        with:
+          csp_branch: ${{inputs.csp_branch}}
+          build_type: ${{ matrix.build_type }}
+
       - name: Install CSP Consumer Dependencies (temp) # We shouldn't need to do this forever, the new CSP build system is just under development and we haven't properly expunged public symbols yet.
-        if: env.BUILDING_FROM_BRANCH == 'true' && runner.os == 'Windows'
+        if: env.BUILDING_FROM_BRANCH == 'true'
         run: |
           pip install "conan==2.27.0"
           conan install . --output-folder=build --build=missing -s build_type=${{ matrix.build_type }};

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -26,6 +26,10 @@ on:
         type: string
         required: false
         default: ''
+      binding_repo_branch: # Branch of this (.net bindings) repo to check out. Required when called from another repo so the local actions resolve correctly. Leave empty when running this workflow natively.
+        type: string
+        required: false
+        default: ''
 
 env:
   BUILDING_FROM_BRANCH: ${{ inputs.csp_branch != '' }}
@@ -45,7 +49,18 @@ jobs:
       GH_TOKEN: ${{ github.token }}
 
     steps:
-      - name: Checkout
+      # When called from another repo (workflow_call), the default checkout would target the
+      # caller's repo because github.repository resolves to the caller. The binding_repo_branch input
+      # is the explicit signal: caller passes the branch of this repo to check out.
+      - name: Checkout (called from another repo)
+        if: inputs.binding_repo_branch != ''
+        uses: actions/checkout@v4
+        with:
+          repository: magnopus-opensource/connected-spaces-platform-unity
+          ref: ${{ inputs.binding_repo_branch }}
+
+      - name: Checkout (native)
+        if: inputs.binding_repo_branch == ''
         uses: actions/checkout@v4
 
       - name: Setup .NET

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,21 @@ set(_DEPS_DIR "${CMAKE_BINARY_DIR}/_deps")
 include(FetchContent)
 include(cmake/Options.cmake)
 include(cmake/GetSwig.cmake)
-include(cmake/GetCSP.cmake)
+
+if(LEGACY_BUILD_SYSTEM)
+  include(cmake/GetCSP.cmake)
+  set(CSP_INCLUDE_DIR "${_CSP_INCLUDE_DIR}")
+  set(_CSP_TARGET_NAME "_CSP")
+  # Assume if we're building shared, then we're trying to build from a shared CSP
+  # Not technically correct, the non-legacy build system provides a mechanism
+  # to make the distinction as is proper.
+  set(CSP_BUILT_SHARED ${BUILD_SHARED_LIBS})
+else()
+  find_package(CSP CONFIG REQUIRED)
+  set(_CSP_TARGET_NAME "CSP::csp-lib")
+  get_target_property(_CSP_LIB_DIR ${_CSP_TARGET_NAME} LOCATION)
+  get_filename_component(_CSP_LIB_DIR "${_CSP_LIB_DIR}" DIRECTORY)
+endif()
 
 # Global configuration. This should have RelWithDebugInfo in it also, 
 # but we don't have CSP libs for it yet. Impressed that CMake forced
@@ -63,6 +77,26 @@ endif()
 # the targeted platform (see the LibName constant in main.i for more details). 
 set(DLL_NAME_FOR_LINKING "DLL_NAME_FOR_LINKING_TO_BE_PATCHED")
 
+# Preprocess CSP includes to guard the legacy wrapper gen NO_EXPORT declarations so they don't confuse us
+if(GUARD_CSP_NO_EXPORTS)
+    # Trim the CSP_NO_EXPORT stuff off so SWIG dosen't try to generate it
+  find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+  message("Guarding CSP include dir files from NO_EXPORT sections")
+
+  set(CSP_FILTERED_INCLUDE_DIR "${CMAKE_BINARY_DIR}/csp_filtered_include")
+  execute_process(
+    COMMAND "${Python3_EXECUTABLE}"
+            "${CMAKE_SOURCE_DIR}/Utilities/GuardNoExports/GuardNoExports.py"
+            "${CSP_INCLUDE_DIR}"          
+            "${CSP_FILTERED_INCLUDE_DIR}" 
+      COMMAND_ERROR_IS_FATAL ANY)
+
+  # Rebind Cmake state to point to the new filtered include dir
+  set(CSP_INCLUDE_DIR "${CSP_FILTERED_INCLUDE_DIR}")
+  set_target_properties(${_CSP_TARGET_NAME} PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${CSP_FILTERED_INCLUDE_DIR}")
+endif()
+
 # Setup SWIG invocation
 add_custom_command(
   OUTPUT "${_CPP_WRAPPER_OUT}"
@@ -70,7 +104,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E remove_directory "${_GEN_CS_DIR}"
   COMMAND "${CMAKE_COMMAND}" -E make_directory "${_GEN_CPP_DIR}" "${_GEN_CS_DIR}"
   COMMAND "${SWIG_EXE}"
-          -I${_CSP_INCLUDE_DIR} # So we can #include CSP's .h files.
+          -I${CSP_INCLUDE_DIR} # So we can #include CSP's .h files.
           -I${ROOT_I_DIR} # So we can %include our own .i files.
           -I${_INTERNAL_SWG_SEARCH_PATH_CSHARP} # C# search path for SWIG .i lib files. (This should be first as some are named the same)
           -I${_INTERNAL_SWG_SEARCH_PATH_GLOBAL} # Global search path for SWIG .i lib files.
@@ -103,12 +137,26 @@ add_custom_command(
 # ---------------- Build SWIG Output ----------------
 if (BUILD_SHARED_LIBS)
   add_library(${_WRAPPER_MODULE_NAME} SHARED "${_CPP_WRAPPER_OUT}")
-  # Pretty important, make sure we're importing symbols. 
-  # Otherwise you'll get duplicate template instances and such. Bad times.
-  target_compile_definitions(${_WRAPPER_MODULE_NAME} PRIVATE USING_CSP_DLL)
 else()
   add_library(${_WRAPPER_MODULE_NAME} STATIC "${_CPP_WRAPPER_OUT}")
 endif()
+
+# Force /MD (Release runtime) to match CSP DLL runtime library settings
+# This is an unexpected choice from CSP's end. I hope this changes.
+# https://github.com/magnopus-opensource/connected-spaces-platform/blob/15f530fdd7a8b1782772338eee637e989057c815/premake5_helpers.lua#L124
+if(MSVC AND LEGACY_BUILD_SYSTEM)
+  target_compile_options(${_WRAPPER_MODULE_NAME} PRIVATE
+    $<$<CONFIG:Debug>:/MD>
+    $<$<CONFIG:Release>:/MD>
+  )
+endif()
+
+if (CSP_BUILT_SHARED)
+  # Pretty important, make sure we're importing symbols. 
+  # Otherwise you'll get duplicate template instances and such. Bad times.
+  target_compile_definitions(${_WRAPPER_MODULE_NAME} PRIVATE USING_CSP_DLL)
+endif()
+
 set_target_properties(${_WRAPPER_MODULE_NAME} PROPERTIES
   CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
@@ -117,22 +165,12 @@ set_target_properties(${_WRAPPER_MODULE_NAME} PROPERTIES
 )
 
 # Add CSP Target to our output library, this produces a final API that can use CSP.
-target_link_libraries(${_WRAPPER_MODULE_NAME} PRIVATE _CSP)
+target_link_libraries(${_WRAPPER_MODULE_NAME} PRIVATE ${_CSP_TARGET_NAME})
 
 if(CMAKE_SYSTEM_NAME STREQUAL "iOS" OR CMAKE_SYSTEM_NAME STREQUAL "visionOS")
     # Additionally, on iOS and visionOS we have to force load the CSP static library because the dynamic lookup doesn't 
     # work with static libraries, and we don't have a choice but to use static libs on iOS.
-    target_link_options(${_WRAPPER_MODULE_NAME} PRIVATE "-Wl,-force_load,$<TARGET_FILE:_CSP>")
-endif()
-
-# Force /MD (Release runtime) to match CSP DLL runtime library settings
-# This is an unexpected choice from CSP's end. I hope this changes.
-# https://github.com/magnopus-opensource/connected-spaces-platform/blob/15f530fdd7a8b1782772338eee637e989057c815/premake5_helpers.lua#L124
-if(MSVC)
-  target_compile_options(${_WRAPPER_MODULE_NAME} PRIVATE
-    $<$<CONFIG:Debug>:/MD>
-    $<$<CONFIG:Release>:/MD>
-  )
+    target_link_options(${_WRAPPER_MODULE_NAME} PRIVATE "-Wl,-force_load,$<TARGET_FILE:${_CSP_TARGET_NAME}>")
 endif()
 
 # Ensure the wrapper can resolve @rpath by looking in its own folder at runtime.

--- a/cmake/GetCSP.cmake
+++ b/cmake/GetCSP.cmake
@@ -89,24 +89,6 @@ else()
   message(STATUS "Using CSP_ROOT_DIR=${CSP_ROOT_DIR}, CSP download skipped.")
 endif()
 
-if(GUARD_CSP_NO_EXPORTS)
-    # Trim the CSP_NO_EXPORT stuff off so SWIG dosen't try to generate it
-    find_package(Python3 REQUIRED COMPONENTS Interpreter)
-
-    message("Guarding CSP include dir files from NO_EXPORT sections")
-
-    # Move the old include dir aside, since we want the trimmed dir to be called that.
-    file(RENAME "${CSP_ROOT_DIR}/include" "${CSP_ROOT_DIR}/include_orig")
-
-    # Perform the strip using the utility python script.
-    execute_process(
-        COMMAND "${Python3_EXECUTABLE}"
-                "${CMAKE_SOURCE_DIR}/Utilities/GuardNoExports/GuardNoExports.py"
-                "${CSP_ROOT_DIR}/include_orig"
-                "${CSP_ROOT_DIR}/include"
-        COMMAND_ERROR_IS_FATAL ANY)
-endif()
-
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(_CSP_NAME "libConnectedSpacesPlatform_D.dylib")
 else()
@@ -203,4 +185,3 @@ else()
         )
     endif()
 endif()
-

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -8,3 +8,4 @@ option(GUARD_CSP_NO_EXPORTS "Invoke Utilities/GuardNoExports to IFDEF guard the 
 option(COPY_OUTPUT_TO_UNITY_TEST_PROJECT "Copy the latest generated classes and libraries to the Unity test project" ON)
 option(ENABLE_UNITY_EXTENSIONS "Generate additional type conversions to and from common UnityEngine types" OFF)
 option(ENABLE_THROW_EXCEPTION_ON_RESULTBASE_FAILURE "Generate ThrowOnFailure code to throw exceptions when ResultBase is returned with failure status code" ON)
+option(LEGACY_BUILD_SYSTEM "Using a CSP binary produced from the legacy CSP build system" ON)

--- a/cmake/PackageInstall.cmake
+++ b/cmake/PackageInstall.cmake
@@ -3,6 +3,10 @@
 # In the future, this might want to produce something friendlier for CSharp,
 # currently it ships the necessary .dll/.so's, as well as the .cs files that serve as includes.
 # I'm not totally sure about the ecosystem. Do you ship .csproj files?
+# Some variables, like _CSP_LIB_DIR and _CSP_BUILT_SHARED, may be being set
+# from the branching between legacy and non legacy builds in the top-level CMakeLists.txt.
+# They should be functionally identical as far as the install is concerned for both modes,
+# but be aware nonetheless.
 
 set(INSTALL_DIR "${CMAKE_SOURCE_DIR}/install" CACHE FILEPATH "Directory to install output .cs and shared libraries")
 
@@ -50,39 +54,38 @@ install(
 
 # The actual underlying CSP library, needs to sit alongside the bindings.
 # Including this makes this a complete artifact.
-if (BUILD_SHARED_LIBS)
+if (CSP_BUILT_SHARED)
   install(
-    FILES $<TARGET_FILE:_CSP>
+    FILES $<TARGET_FILE:${_CSP_TARGET_NAME}>
     DESTINATION ${INSTALL_DIR}/bin
   )
-endif()
-
-if(APPLE)
-    if(CMAKE_SYSTEM_NAME STREQUAL "iOS" OR CMAKE_SYSTEM_NAME STREQUAL "visionOS")
-        # Copy the original CSP libraries alongside the one we created via SWIG
-        install(DIRECTORY "${_CSP_LIB_DIR}/"
-                DESTINATION "${INSTALL_DIR}/lib")
-    endif()
 endif()
 
 # Finally the underlying CSP's debug symbols on windows platforms (no pdb equivalent on unix).
 # TARGET_PDB_FILE is not available for imported targets (why though?)
 # So do it more explicitly.
-if(MSVC AND BUILD_SHARED_LIBS)
+if(MSVC AND CSP_BUILT_SHARED)
+  # OPTIONAL: the new (non-legacy) CSP build system does not yet ship PDBs.
+  # Once it does, these will start installing automatically with no code change.
   install(FILES "${_CSP_LIB_DIR}/ConnectedSpacesPlatform_D.pdb"
           DESTINATION "${INSTALL_DIR}/bin"
-          CONFIGURATIONS Debug)
+          CONFIGURATIONS Debug
+          OPTIONAL)
 
   install(FILES "${_CSP_LIB_DIR}/ConnectedSpacesPlatform.pdb"
           DESTINATION "${INSTALL_DIR}/bin"
-          CONFIGURATIONS RelWithDebInfo)
-elseif(APPLE AND BUILD_SHARED_LIBS)
+          CONFIGURATIONS RelWithDebInfo
+          OPTIONAL)
+elseif(APPLE AND CSP_BUILT_SHARED)
     # This is redundant I think, CSP could build DWARF with debug symbols embedded, I don't think dSYMs are the norm?
+    # OPTIONAL: the new (non-legacy) CSP build system does not yet ship dSYMs.
     install(DIRECTORY "${_CSP_LIB_DIR}/libConnectedSpacesPlatform_D.dylib.dSYM"
             DESTINATION "${INSTALL_DIR}/bin"
-            CONFIGURATIONS Debug)
-          
+            CONFIGURATIONS Debug
+            OPTIONAL)
+
     install(DIRECTORY "${_CSP_LIB_DIR}/libConnectedSpacesPlatform.dylib.dSYM"
             DESTINATION "${INSTALL_DIR}/bin"
-            CONFIGURATIONS RelWithDebInfo)
+            CONFIGURATIONS RelWithDebInfo
+            OPTIONAL)
 endif()

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,8 @@
+[requires]
+fmt/12.1.0
+rapidjson/cci.20250205
+asyncplusplus/1.2
+
+[generators]
+CMakeDeps
+CMakeToolchain


### PR DESCRIPTION
This PR won't make a whole lot of sense without also being across the following CSP PRs :
- https://github.com/magnopus-opensource/connected-spaces-platform/pull/954
- https://github.com/magnopus-opensource/connected-spaces-platform/pull/950

Adds a way of running the Unity binding build+test pipeline from a version of CSP fetched from a branch, built live on actions. This is cool. Since these workflows also upload artifacts, this creates a powerful way to get access to experimental CSP changes via the .NET runtime. However, the primary motivation is to allow CSP to run the integration bindings build + tests during its own PR process, creating a gate for breaking build changes, which should mean we address breaking changes at the exact same time as they are merged upstream, preventing the weeks of lag we always see.

<img width="412" height="816" alt="image" src="https://github.com/user-attachments/assets/8479866a-7015-4f5c-80ce-72db591354ad" />

Can see this working [here](https://github.com/magnopus-opensource/connected-spaces-platform-unity/actions/runs/25184042743/job/73836513721), it won't work until the CSP side changes have been merged. But you can run it via workflow_dispatch against the OF-1793-Unity-SWIG-backwards-integration branch, which has the neccesary changes.

The changeset, on the v.next branch, can be seen [here](https://github.com/magnopus-opensource/connected-spaces-platform-unity/tree/v.next). The CSP repo uses that branch to run its integrations against. This should be synced any time this repo performs a release.

> [!IMPORTANT]
> We will not be merging this until we have demonstrated that the CSP CI can call this workflow remotely and execute it in order to fulfil its PR checks. That's still a possible integration hurdle that might throw a ratchet into this whole affair.
>
> **Update: Proven via [this PR](https://github.com/magnopus-opensource/connected-spaces-platform/pull/950)**
> <img width="998" height="254" alt="image" src="https://github.com/user-attachments/assets/cacb9728-ed13-46c2-8553-4cf67e2e1921" />
