### PR TITLE
Feat/OPE-3282 Add progress to async functions

### DIFF
--- a/InteropTestsXUnit/AsyncTests.cs
+++ b/InteropTestsXUnit/AsyncTests.cs
@@ -317,29 +317,23 @@ public class AsyncInteropTests
     {
         using var logSystem = new LogSystem();
         var progressUpdates = new List<float>();
-        var progressCalled = false;
 
-        Action<float> progressHandler = (progress) =>
+        var result = await logSystem.LogAfterSecondsWithProgressAsync(true, 1, progress =>
         {
             lock (progressUpdates)
             {
-                progressCalled = true;
                 progressUpdates.Add(progress);
             }
-        };
+        });
 
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-
-        var result = await logSystem.LogAfterSecondsAsync(true, 1, progressHandler);
         Assert.True(result.GetValue());
         
-        if (progressCalled)
-        {
-            Assert.NotEmpty(progressUpdates);
-            // Verify progress always positive
-            Assert.All(progressUpdates, p => Assert.True(p >= 0f));
-        }
+        // We expect exactly 3 InProgress ticks (25, 50, 75). 
+        // (The terminal 100% success is intercepted by macro's tcs completion layer)
+        Assert.Equal(3, progressUpdates.Count);
+        Assert.Equal(25.0f, progressUpdates[0]);
+        Assert.Equal(50.0f, progressUpdates[1]);
+        Assert.Equal(75.0f, progressUpdates[2]);
     }
 
     [Fact(DisplayName = "Async method handles null progress parameter gracefully without crashing")]
@@ -396,31 +390,28 @@ public class AsyncInteropTests
     public async Task AsyncProgress_OnCompletion_CleanlyUnrootsCallbackMemory()
     {
         using LogSystem logSystem = new LogSystem();
-        
-        // Note: trying to check AsyncLifeTime objects while cooping with parallel execution of tests.
-        var rootsField = typeof(ConnectedSpacesPlatformDotNet)
-            .GetNestedType("AsyncLifetime", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
-            ?.GetField("_roots", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        var progressFiredCount = 0;
 
-        Assert.NotNull(rootsField);
-        var rootsDictionary = rootsField.GetValue(null) as System.Collections.IDictionary;
-        Assert.NotNull(rootsDictionary);
+        System.Action<float>? progressHandler = (progress) =>
+        {
+            progressFiredCount++;
+        };
 
-        var initialKeys = new HashSet<object>(rootsDictionary.Keys.Cast<object>());
+        var handlerWeakRef = new WeakReference(progressHandler);
+        var result = await logSystem.LogAfterSecondsWithProgressAsync(true, 1, progressHandler);
 
-        var result = await logSystem.LogAfterSecondsAsync(true, 0, progress => { /* no-op */ });
         Assert.True(result.GetValue());
+        Assert.True(progressFiredCount > 0, "The progress update callback layer failed to execute.");
 
+        // Sever our own local strong reference so the GC is free to collect it
+        progressHandler = null;
+
+        // Force an immediate Garbage Collection sweep
         GC.Collect();
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var currentKeys = rootsDictionary.Keys.Cast<object>().ToList();
-
-        var ourActiveCallbacks = currentKeys
-            .Where(key => !initialKeys.Contains(key) && key.GetType().Name == "TestBooleanResultCallback")
-            .ToList();
-
-        Assert.Empty(ourActiveCallbacks);
+        // If the framework cleanly unrooted the callback pipeline, the progress handler object is gone from memory.
+        Assert.False(handlerWeakRef.IsAlive, "The progress handler delegate is still alive in memory, indicating a root leak.");
     }
 }

--- a/InteropTestsXUnit/AsyncTests.cs
+++ b/InteropTestsXUnit/AsyncTests.cs
@@ -311,4 +311,116 @@ public class AsyncInteropTests
 
         await Task.WhenAll(tasks);
     }
+    
+    [Fact(DisplayName = "Async method with progress callback invokes handler sequentially")]
+    public async Task Async_WithProgressCallback_InvokesProgressSequentially()
+    {
+        using var logSystem = new LogSystem();
+        var progressUpdates = new List<float>();
+        var progressCalled = false;
+
+        Action<float> progressHandler = (progress) =>
+        {
+            lock (progressUpdates)
+            {
+                progressCalled = true;
+                progressUpdates.Add(progress);
+            }
+        };
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+
+        var result = await logSystem.LogAfterSecondsAsync(true, 1, progressHandler);
+        Assert.True(result.GetValue());
+        
+        if (progressCalled)
+        {
+            Assert.NotEmpty(progressUpdates);
+            // Verify progress always positive
+            Assert.All(progressUpdates, p => Assert.True(p >= 0f));
+        }
+    }
+
+    [Fact(DisplayName = "Async method handles null progress parameter gracefully without crashing")]
+    public async Task Async_NullProgressCallback_CompletesSuccessfully()
+    {
+        using LogSystem logSystem = new LogSystem();
+        var result = await logSystem.LogAfterSecondsAsync(true, 1, progressCallback: null);
+        Assert.True(result.GetValue());
+    }
+
+    [Fact(DisplayName = "Concurrent async calls completely isolate unique progress callback states")]
+    public async Task ConcurrentCalls_IsolateUniqueProgressCallbacks()
+    {
+        using LogSystem logSystem = new LogSystem();
+
+        var operation1Progress = new List<float>();
+        var operation2Progress = new List<float>();
+
+        var task1 = logSystem.LogAfterSecondsAsync(true, 1, p => { lock(operation1Progress) operation1Progress.Add(p); });
+        var task2 = logSystem.LogAfterSecondsAsync(true, 1, p => { lock(operation2Progress) operation2Progress.Add(p); });
+
+        await Task.WhenAll(task1, task2);
+
+        Assert.True(task1.Result.GetValue());
+        Assert.True(task2.Result.GetValue());
+    }
+
+    [EnvironmentFact("RUN_LONG_RUNNING_TESTS", DisplayName = "Async progress handlers survive extreme GC pressure under heavy load")]
+    public async Task AsyncProgress_Survives_Extreme_GC_Pressure()
+    {
+        using var logSystem = new LogSystem();
+        int totalOps = 100;
+        int progressCallbacksFired = 0;
+
+        var tasks = Enumerable.Range(0, totalOps)
+            .Select(_ => logSystem.LogAfterSecondsAsync(true, 0, p => Interlocked.Increment(ref progressCallbacksFired)))
+            .ToArray();
+
+        for (var i = 0; i < 3; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            await Task.Delay(5, TestContext.Current.CancellationToken);
+        }
+
+        var results = await Task.WhenAll(tasks);
+        
+        Assert.Equal(totalOps, results.Length);
+        Assert.All(results, r => Assert.True(r.GetValue()));
+    }
+    
+    [Fact(DisplayName = "Async progress pipeline cleanly unroots and releases callback memory on completion")]
+    public async Task AsyncProgress_OnCompletion_CleanlyUnrootsCallbackMemory()
+    {
+        using LogSystem logSystem = new LogSystem();
+        
+        // Note: trying to check AsyncLifeTime objects while cooping with parallel execution of tests.
+        var rootsField = typeof(ConnectedSpacesPlatformDotNet)
+            .GetNestedType("AsyncLifetime", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+            ?.GetField("_roots", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        Assert.NotNull(rootsField);
+        var rootsDictionary = rootsField.GetValue(null) as System.Collections.IDictionary;
+        Assert.NotNull(rootsDictionary);
+
+        var initialKeys = new HashSet<object>(rootsDictionary.Keys.Cast<object>());
+
+        var result = await logSystem.LogAfterSecondsAsync(true, 0, progress => { /* no-op */ });
+        Assert.True(result.GetValue());
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var currentKeys = rootsDictionary.Keys.Cast<object>().ToList();
+
+        var ourActiveCallbacks = currentKeys
+            .Where(key => !initialKeys.Contains(key) && key.GetType().Name == "TestBooleanResultCallback")
+            .ToList();
+
+        Assert.Empty(ourActiveCallbacks);
+    }
 }

--- a/UnityProject/CspUnityTests/Assets/Scripts/UnitTests/AsyncTest.cs
+++ b/UnityProject/CspUnityTests/Assets/Scripts/UnitTests/AsyncTest.cs
@@ -55,22 +55,17 @@ namespace Magnopus.Csp.Unity.Tests
                 yield break;
             }
             
-            // Unwrap AggregateException so NUnit reports correctly
-            if (task.Exception != null)
+            if (task.Exception?.InnerException != null)
             {
-                if (task.Exception.InnerException != null)
-                {
-                    throw task.Exception.InnerException;
-                }
+                throw task.Exception.InnerException;
             }
-            else
-            {
-                throw new Exception("Task faulted without exception details.");
-            }
+            
+            throw new Exception("Task faulted without exception details.");
         }
     }
     
     [TestFixture]
+    [Parallelizable(ParallelScope.None)]
     public class LogSystemAsyncTests
     {
         [UnityTest]
@@ -268,30 +263,20 @@ namespace Magnopus.Csp.Unity.Tests
                 var progressUpdates = new List<float>();
                 var progressCalled = false;
 
-                Action<float> progressHandler = (progress) =>
+                var result = await logSystem.LogAfterSecondsWithProgressAsync(true, 1, progress =>
                 {
                     lock (progressUpdates)
                     {
-                        progressCalled = true;
                         progressUpdates.Add(progress);
                     }
-                };
+                });
 
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-
-                var result = await logSystem.LogAfterSecondsAsync(true, 1, progressHandler);
                 Assert.NotNull(result);
                 Assert.IsTrue(result.GetValue());
-                
-                if (progressCalled)
-                {
-                    Assert.IsNotEmpty(progressUpdates);
-                    foreach (var p in progressUpdates)
-                    {
-                        Assert.GreaterOrEqual(p, 0f);
-                    }
-                }
+                Assert.AreEqual(3, progressUpdates.Count);
+                Assert.AreEqual(25.0f, progressUpdates[0]);
+                Assert.AreEqual(50.0f, progressUpdates[1]);
+                Assert.AreEqual(75.0f, progressUpdates[2]);
             });
         }
 
@@ -364,29 +349,28 @@ namespace Magnopus.Csp.Unity.Tests
             yield return AsyncTest.RunAsync(async () =>
             {
                 var logSystem = new LogSystem();
-                
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                
-                var result = await logSystem.LogAfterSecondsAsync(true, 0, progress => { /* no-op */ });
-                Assert.IsTrue(result.GetValue());
+                var progressFiredCount = 0;
 
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                GC.Collect();
-
-                // Use reflection to inspect the private '_roots' dictionary inside the static AsyncLifetime class.
-                // This ensures the custom macro tracking cleanly detached everything on completion.
-                var rootsField = typeof(ConnectedSpacesPlatformDotNet)
-                    .GetNestedType("AsyncLifetime", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
-                    ?.GetField("_roots", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-
-                if (rootsField != null)
+                Action<float>? progressHandler = (progress) =>
                 {
-                    var rootsDictionary = rootsField.GetValue(null) as System.Collections.IDictionary;
-                    Assert.NotNull(rootsDictionary);
-                    Assert.IsEmpty(rootsDictionary);
-                }
+                    progressFiredCount++;
+                };
+
+                var handlerWeakRef = new WeakReference(progressHandler);
+
+                var result = await logSystem.LogAfterSecondsWithProgressAsync(true, 1, progressHandler);
+                Assert.IsTrue(result.GetValue());
+                Assert.Greater(progressFiredCount, 0);
+
+                // Nullify our local variable to clear our strong reference link
+                progressHandler = null;
+
+                // Force garbage collection sweeps within the Unity runner context
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+                
+                Assert.False(handlerWeakRef.IsAlive, "The progress handler delegate leaked and remains rooted in memory.");
             });
         }
 #endif

--- a/UnityProject/CspUnityTests/Assets/Scripts/UnitTests/AsyncTest.cs
+++ b/UnityProject/CspUnityTests/Assets/Scripts/UnitTests/AsyncTest.cs
@@ -258,6 +258,137 @@ namespace Magnopus.Csp.Unity.Tests
                 await Task.WhenAll(tasks);
             });
         }
+
+        [UnityTest]
+        public IEnumerator Async_WithProgressCallback_InvokesProgressSequentially()
+        {
+            yield return AsyncTest.RunAsync(async () =>
+            {
+                var logSystem = new LogSystem();
+                var progressUpdates = new List<float>();
+                var progressCalled = false;
+
+                Action<float> progressHandler = (progress) =>
+                {
+                    lock (progressUpdates)
+                    {
+                        progressCalled = true;
+                        progressUpdates.Add(progress);
+                    }
+                };
+
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+
+                var result = await logSystem.LogAfterSecondsAsync(true, 1, progressHandler);
+                Assert.NotNull(result);
+                Assert.IsTrue(result.GetValue());
+                
+                if (progressCalled)
+                {
+                    Assert.IsNotEmpty(progressUpdates);
+                    foreach (var p in progressUpdates)
+                    {
+                        Assert.GreaterOrEqual(p, 0f);
+                    }
+                }
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator Async_NullProgressCallback_CompletesSuccessfully()
+        {
+            yield return AsyncTest.RunAsync(async () =>
+            {
+                var logSystem = new LogSystem();
+                var result = await logSystem.LogAfterSecondsAsync(true, 1, progressCallback: null);
+                
+                Assert.NotNull(result);
+                Assert.IsTrue(result.GetValue());
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator ConcurrentCalls_IsolateUniqueProgressCallbacks()
+        {
+            yield return AsyncTest.RunAsync(async () =>
+            {
+                var logSystem = new LogSystem();
+                var operation1Progress = new List<float>();
+                var operation2Progress = new List<float>();
+
+                var task1 = logSystem.LogAfterSecondsAsync(true, 1, p => { lock(operation1Progress) operation1Progress.Add(p); });
+                var task2 = logSystem.LogAfterSecondsAsync(true, 1, p => { lock(operation2Progress) operation2Progress.Add(p); });
+
+                await Task.WhenAll(task1, task2);
+
+                Assert.IsTrue(task1.Result.GetValue());
+                Assert.IsTrue(task2.Result.GetValue());
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator AsyncProgress_Survives_Extreme_GC_Pressure()
+        {
+            yield return AsyncTest.RunAsync(async () =>
+            {
+                var logSystem = new LogSystem();
+                int totalOps = 100;
+                int progressCallbacksFired = 0;
+
+                var tasks = Enumerable.Range(0, totalOps)
+                    .Select(_ => logSystem.LogAfterSecondsAsync(true, 0, p => Interlocked.Increment(ref progressCallbacksFired)))
+                    .ToArray();
+
+                for (int i = 0; i < 3; i++)
+                {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    GC.Collect();
+                    await Task.Delay(5);
+                }
+
+                var results = await Task.WhenAll(tasks);
+                
+                Assert.AreEqual(totalOps, results.Length);
+                foreach (var r in results)
+                {
+                    Assert.IsTrue(r.GetValue());
+                }
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator AsyncProgress_OnCompletion_CleanlyUnrootsCallbackMemory()
+        {
+            yield return AsyncTest.RunAsync(async () =>
+            {
+                var logSystem = new LogSystem();
+                
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                
+                var result = await logSystem.LogAfterSecondsAsync(true, 0, progress => { /* no-op */ });
+                Assert.IsTrue(result.GetValue());
+
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+
+                // Use reflection to inspect the private '_roots' dictionary inside the static AsyncLifetime class.
+                // This ensures the custom macro tracking cleanly detached everything on completion.
+                var rootsField = typeof(ConnectedSpacesPlatformDotNet)
+                    .GetNestedType("AsyncLifetime", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+                    ?.GetField("_roots", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+                if (rootsField != null)
+                {
+                    var rootsDictionary = rootsField.GetValue(null) as System.Collections.IDictionary;
+                    Assert.NotNull(rootsDictionary);
+                    Assert.IsEmpty(rootsDictionary);
+                }
+            });
+        }
 #endif
     }
 }

--- a/interface/CSP/Common/Systems/Log/LogSystem.i
+++ b/interface/CSP/Common/Systems/Log/LogSystem.i
@@ -25,6 +25,12 @@ namespace extra
             TestBooleanResult(csp::systems::EResultCode ResCode, uint16_t HttpResCode, csp::systems::ERequestFailureReason Reason)
                 : ResultBase(ResCode, HttpResCode, Reason) {}
 
+            void SetRequestProgress(float ProgressPercentage)
+            {
+                RequestProgress = ProgressPercentage;
+                ResponseProgress = ProgressPercentage;
+            }
+
             void SetResult(csp::systems::EResultCode ResCode, uint16_t HttpResCode)
             {
                 ResultBase::SetResult(ResCode, HttpResCode);
@@ -90,6 +96,55 @@ namespace extra
         }).detach();
     }
 
+    /// <summary>
+    /// Test function explicitly designed to isolate progress callback pipelines.
+    /// By default send exactly 4 progress increments over 4 equal intervals based on total seconds.
+    /// </summary>
+    void LogAfterSecondsWithProgress(bool value, int seconds, extra::test::TestBooleanResultCallback callback, int totalProgressSteps = 4)
+    {
+        std::thread([value, seconds, callback, totalProgressSteps]() mutable 
+        {
+            const int acceptedHttpCode = 202;
+
+            if (seconds > 0)
+            {
+                auto stepDuration = std::chrono::milliseconds((seconds * 1000) / totalProgressSteps);
+                for (int i = 1; i < totalProgressSteps; ++i)
+                {
+                    std::this_thread::sleep_for(stepDuration);
+
+                    extra::test::TestBooleanResult progressResult(
+                        csp::systems::EResultCode::InProgress,
+                        acceptedHttpCode
+                    );
+                    
+                    float calculatedProgress = (static_cast<float>(i) / totalProgressSteps) * 100.0f;
+                    progressResult.SetRequestProgress(calculatedProgress);
+                    callback(progressResult);
+                }
+                
+                std::this_thread::sleep_for(stepDuration);
+            }
+            else
+            {
+                // Fallback for an instant execution: fire a quick 50% midpoint update
+                extra::test::TestBooleanResult instantProgress(csp::systems::EResultCode::InProgress, acceptedHttpCode);
+                instantProgress.SetRequestProgress(50.0f);
+                callback(instantProgress);
+            }
+
+            // Construct terminal result context block
+            extra::test::TestBooleanResult result(
+                value ? csp::systems::EResultCode::Success : csp::systems::EResultCode::Failed,
+                value ? 200 : 500
+            );
+            result.SetValue(value);
+            result.SetRequestProgress(100.0f);
+
+            callback(result);
+        }).detach();
+    }
+
     /// <summary> 
 	/// Throws an exception to test that it is properly propagated to C#.
     /// Note: SWIG cannot catch this exception because the thread is detached and the callback is not invoked. This is
@@ -135,6 +190,17 @@ MAKE_AWAITABLE(csp::common::LogSystem,
           ARGLIST(result),
 		  ARGLIST(bool boolValue, int seconds),
 		  ARGLIST(boolValue, seconds)
+)
+
+MAKE_AWAITABLE(csp::common::LogSystem,
+          LogAfterSecondsWithProgress,
+          TestBooleanResultCallback,
+          TestBooleanResultCallbackAdapter,
+          ARGLIST(extra.test.TestBooleanResult result),
+          ARGLIST(extra.test.TestBooleanResult),
+          ARGLIST(result),
+          ARGLIST(bool boolValue, int seconds),
+          ARGLIST(boolValue, seconds)
 )
 
 MAKE_AWAITABLE_ZERO(csp::common::LogSystem,

--- a/interface/Declarations/EventsDeclarations.i
+++ b/interface/Declarations/EventsDeclarations.i
@@ -18,6 +18,30 @@ MAKE_EVENT_FOR_CALLBACK(
     csp::common::LogSystem
 )
 
+MAKE_EVENT_FOR_CALLBACK(
+    OnEvent,
+    EventCallback,
+    SetEventCallback,
+    string,
+    csp::common::LogSystem
+)
+
+MAKE_EVENT_FOR_CALLBACK(
+    OnBeginMarker,
+    BeginMarkerCallback,
+    SetBeginMarkerCallback,
+    string,
+    csp::common::LogSystem
+)
+
+MAKE_EVENT_FOR_CALLBACK(
+    OnEndMarker,
+    EndMarkerCallback,
+    SetEndMarkerCallback,
+    System.IntPtr,
+    csp::common::LogSystem
+)
+
 /* csp::systems::AssetSystem events */
 MAKE_EVENT_FOR_CALLBACK(
     UploadAssetDataExOnProgress,

--- a/interface/Declarations/EventsDeclarations.i
+++ b/interface/Declarations/EventsDeclarations.i
@@ -78,6 +78,24 @@ MAKE_EVENT_FOR_CALLBACK(
     csp::multiplayer::MultiplayerConnection
 )
 
+/* csp::multiplayer::SpaceEntity events */
+
+MAKE_EVENT_FOR_CALLBACK(
+    OnUpdate,
+    UpdateCallback,
+    SetUpdateCallback,
+    ARGLIST(csp.multiplayer.SpaceEntity, csp.multiplayer.SpaceEntityUpdateFlags, csp.common.ComponentUpdateInfoArray),
+    csp::multiplayer::SpaceEntity
+)
+
+MAKE_EVENT_FOR_CALLBACK(
+    OnDestroy,
+    DestroyCallback,
+    SetDestroyCallback,
+    bool,
+    csp::multiplayer::SpaceEntity
+)
+
 /* csp::systems::AssetSystem events */
 MAKE_EVENT_FOR_CALLBACK(
     UploadAssetDataExOnProgress,

--- a/interface/Declarations/EventsDeclarations.i
+++ b/interface/Declarations/EventsDeclarations.i
@@ -175,6 +175,16 @@ MAKE_EVENT_FOR_CALLBACK(
     csp::systems::HotspotSequenceSystem
 )
 
+/* csp::systems::SpaceSystem events */
+
+MAKE_EVENT_FOR_CALLBACK(
+    OnAsyncCallCompleted,
+    AsyncCallCompletedCallback,
+    SetAsyncCallCompletedCallback,
+    csp.common.AsyncCallCompletedEventData,
+    csp::systems::SpaceSystem
+)
+
 /* csp::systems::UserSystem events */
 MAKE_EVENT_FOR_CALLBACK(
     OnNewLoginTokenReceived,

--- a/interface/Declarations/EventsDeclarations.i
+++ b/interface/Declarations/EventsDeclarations.i
@@ -78,6 +78,16 @@ MAKE_EVENT_FOR_CALLBACK(
     csp::multiplayer::MultiplayerConnection
 )
 
+/* csp::multiplayer::OfflineRealtimeEngine events */
+
+MAKE_EVENT_FOR_CALLBACK(
+    OnEntityFetchComplete,
+    EntityFetchCompleteCallback,
+    SetEntityFetchCompleteCallback,
+    uint,
+    csp::multiplayer::OfflineRealtimeEngine
+)
+
 /* csp::multiplayer::SpaceEntity events */
 
 MAKE_EVENT_FOR_CALLBACK(

--- a/interface/Declarations/EventsDeclarations.i
+++ b/interface/Declarations/EventsDeclarations.i
@@ -52,6 +52,32 @@ MAKE_EVENT_FOR_CALLBACK(
     csp::multiplayer::ConversationSpaceComponent
 )
 
+/* csp::multiplayer::MultiplayerConnection events */
+
+MAKE_EVENT_FOR_CALLBACK(
+    OnConnection,
+    ConnectionCallback,
+    SetConnectionCallback,
+    string,
+    csp::multiplayer::MultiplayerConnection
+)
+
+MAKE_EVENT_FOR_CALLBACK(
+    OnDisconnection,
+    DisconnectionCallback,
+    SetDisconnectionCallback,
+    string,
+    csp::multiplayer::MultiplayerConnection
+)
+
+MAKE_EVENT_FOR_CALLBACK(
+    OnNetworkInterruption,
+    NetworkInterruptionCallback,
+    SetNetworkInterruptionCallback,
+    string,
+    csp::multiplayer::MultiplayerConnection
+)
+
 /* csp::systems::AssetSystem events */
 MAKE_EVENT_FOR_CALLBACK(
     UploadAssetDataExOnProgress,

--- a/interface/Declarations/EventsDeclarations.i
+++ b/interface/Declarations/EventsDeclarations.i
@@ -42,6 +42,16 @@ MAKE_EVENT_FOR_CALLBACK(
     csp::common::LogSystem
 )
 
+/* csp::multiplayer::ConversationSpaceComponent events */
+
+MAKE_EVENT_FOR_CALLBACK(
+    OnConversationUpdate,
+    ConversationNetworkEventCallback,
+    SetConversationUpdateCallback,
+    csp.common.ConversationNetworkEventData,
+    csp::multiplayer::ConversationSpaceComponent
+)
+
 /* csp::systems::AssetSystem events */
 MAKE_EVENT_FOR_CALLBACK(
     UploadAssetDataExOnProgress,

--- a/interface/Declarations/EventsDeclarations.i
+++ b/interface/Declarations/EventsDeclarations.i
@@ -59,6 +59,16 @@ MAKE_EVENT_FOR_CALLBACK(
     csp::systems::AssetSystem
 )
 
+/* csp::systems::HotspotSequenceSystem events */
+
+MAKE_EVENT_FOR_CALLBACK(
+    OnHotspotSequenceChanged,
+    SequenceChangedCallback,
+    SetHotspotSequenceChangedCallback,
+    csp.common.SequenceChangedNetworkEventData,
+    csp::systems::HotspotSequenceSystem
+)
+
 /* csp::systems::UserSystem events */
 MAKE_EVENT_FOR_CALLBACK(
     OnNewLoginTokenReceived,

--- a/interface/Declarations/EventsDeclarations.i
+++ b/interface/Declarations/EventsDeclarations.i
@@ -88,6 +88,24 @@ MAKE_EVENT_FOR_CALLBACK(
     csp::multiplayer::OfflineRealtimeEngine
 )
 
+/* csp::multiplayer::OnlineRealtimeEngine events */
+
+MAKE_EVENT_FOR_CALLBACK(
+    OnRemoteEntityCreated,
+    EntityCreatedCallback,
+    SetRemoteEntityCreatedCallback,
+    csp.multiplayer.SpaceEntity,
+    csp::multiplayer::OnlineRealtimeEngine
+)
+
+MAKE_EVENT_FOR_CALLBACK(
+    OnEntityFetchComplete,
+    EntityFetchCompleteCallback,
+    SetEntityFetchCompleteCallback,
+    uint,
+    csp::multiplayer::OnlineRealtimeEngine
+)
+
 /* csp::multiplayer::SpaceEntity events */
 
 MAKE_EVENT_FOR_CALLBACK(

--- a/interface/Declarations/EventsDeclarations.i
+++ b/interface/Declarations/EventsDeclarations.i
@@ -18,6 +18,47 @@ MAKE_EVENT_FOR_CALLBACK(
     csp::common::LogSystem
 )
 
+/* csp::systems::AssetSystem events */
+MAKE_EVENT_FOR_CALLBACK(
+    UploadAssetDataExOnProgress,
+    ProgressCallback,
+    SetUploadAssetDataExOnProgressCallback,
+    csp.ProgressEventArgs,
+    csp::systems::AssetSystem
+)
+
+MAKE_EVENT_FOR_CALLBACK(
+    UploadAssetDataOnProgress,
+    ProgressCallback,
+    SetUploadAssetDataOnProgressCallback,
+    csp.ProgressEventArgs,
+    csp::systems::AssetSystem
+)
+
+MAKE_EVENT_FOR_CALLBACK(
+    RegisterAssetToLODChainOnProgress,
+    ProgressCallback,
+    SetRegisterAssetToLODChainOnProgressCallback,
+    csp.ProgressEventArgs,
+    csp::systems::AssetSystem
+)
+
+MAKE_EVENT_FOR_CALLBACK(
+    OnAssetDetailBlobChanged,
+    AssetDetailBlobChangedCallback,
+    SetAssetDetailBlobChangedCallback,
+    csp.common.AssetDetailBlobChangedNetworkEventData,
+    csp::systems::AssetSystem
+)
+
+MAKE_EVENT_FOR_CALLBACK(
+    OnMaterialChanged,
+    MaterialChangedCallback,
+    SetMaterialChangedCallback,
+    csp.common.MaterialChangedParams,
+    csp::systems::AssetSystem
+)
+
 /* csp::systems::UserSystem events */
 MAKE_EVENT_FOR_CALLBACK(
     OnNewLoginTokenReceived,

--- a/interface/swigutils/AsyncAdapters.i
+++ b/interface/swigutils/AsyncAdapters.i
@@ -163,6 +163,11 @@ public sealed class ACTION_ADAPTER_TYPENAME : CALLBACKT
                     // Instead, if the result was still pending we would have still needed to await and keep this alive.
                     callback.Invoked -= handler;
                 }
+                else if (_result.GetResultCode() == csp.systems.EResultCode.InProgress)
+                {
+                    // Trigger the injected progress callback.
+                    progressCallback?.Invoke(_result.GetRequestProgress());
+                }
             }
             else
             {
@@ -242,7 +247,7 @@ MAKE_ACTION_ADAPTER(CALLBACK_TYPENAME, CALLBACKT, CALLBACK_TYPELIST_WITH_NAMES, 
 %extend FULLY_NAMESPACED_CLASST {
 %proxycode %{
 
-  public System.Threading.Tasks.Task<CALLBACK_TYPELIST_WITHOUT_NAMES> METHODNAME##Async(FUNCTION_TYPELIST_WITH_NAMES)
+  public System.Threading.Tasks.Task<CALLBACK_TYPELIST_WITHOUT_NAMES> METHODNAME##Async(FUNCTION_TYPELIST_WITH_NAMES, System.Action<float>? progressCallback = null)
   {
     // Create a TaskCompletionSource to represent the async operation.
     System.Threading.Tasks.TaskCompletionSource<CALLBACK_TYPELIST_WITHOUT_NAMES> tcs = 
@@ -288,7 +293,7 @@ MAKE_ACTION_ADAPTER(CALLBACK_TYPENAME, CALLBACKT, CALLBACK_TYPELIST_WITH_NAMES, 
 
 %extend FULLY_NAMESPACED_CLASST {
 %proxycode %{
-  public System.Threading.Tasks.Task<CALLBACK_TYPELIST_WITHOUT_NAMES> METHODNAME##Async()
+  public System.Threading.Tasks.Task<CALLBACK_TYPELIST_WITHOUT_NAMES> METHODNAME##Async(System.Action<float>? progressCallback = null)
   {  
     // Create a TaskCompletionSource to represent the async operation.
     System.Threading.Tasks.TaskCompletionSource<CALLBACK_TYPELIST_WITHOUT_NAMES> tcs = 


### PR DESCRIPTION
Task: https://magnopus.atlassian.net/browse/OPE-3282

Fix issue with progress report requirement on async adapters.
Also add events that Unity client already uses, to match what was generated by the old wrapper generator code.