### PR TITLE
Feat/OPE-3282 Fix unity tests after csp version update

### DIFF
--- a/InteropTestsXUnit/AsyncTests.cs
+++ b/InteropTestsXUnit/AsyncTests.cs
@@ -340,25 +340,36 @@ public class AsyncInteropTests
     public async Task Async_NullProgressCallback_CompletesSuccessfully()
     {
         using LogSystem logSystem = new LogSystem();
-        var result = await logSystem.LogAfterSecondsAsync(true, 1, progressCallback: null);
+        var result = await logSystem.LogAfterSecondsWithProgressAsync(true, 1, progressCallback: null);
         Assert.True(result.GetValue());
     }
 
     [Fact(DisplayName = "Concurrent async calls completely isolate unique progress callback states")]
     public async Task ConcurrentCalls_IsolateUniqueProgressCallbacks()
     {
-        using LogSystem logSystem = new LogSystem();
+        using LogSystem logSystem = new();
 
         var operation1Progress = new List<float>();
         var operation2Progress = new List<float>();
 
-        var task1 = logSystem.LogAfterSecondsAsync(true, 1, p => { lock(operation1Progress) operation1Progress.Add(p); });
-        var task2 = logSystem.LogAfterSecondsAsync(true, 1, p => { lock(operation2Progress) operation2Progress.Add(p); });
+        var task1 = logSystem.LogAfterSecondsWithProgressAsync(true, 1, p => { lock(operation1Progress) operation1Progress.Add(p); });
+        var task2 = logSystem.LogAfterSecondsWithProgressAsync(true, 2, p => { lock(operation2Progress) operation2Progress.Add(p); });
 
         await Task.WhenAll(task1, task2);
 
         Assert.True(task1.Result.GetValue());
         Assert.True(task2.Result.GetValue());
+
+        Assert.NotEmpty(operation1Progress);
+        Assert.NotEmpty(operation2Progress);
+        
+        // Assert the intermediate callbacks worked
+        Assert.Equal(75.0f, operation1Progress.Last());
+        Assert.Equal(75.0f, operation2Progress.Last());
+
+        // Assert the terminal result hit 100%
+        Assert.Equal(100.0f, task1.Result.GetRequestProgress());
+        Assert.Equal(100.0f, task2.Result.GetRequestProgress());
     }
 
     [EnvironmentFact("RUN_LONG_RUNNING_TESTS", DisplayName = "Async progress handlers survive extreme GC pressure under heavy load")]
@@ -369,7 +380,7 @@ public class AsyncInteropTests
         int progressCallbacksFired = 0;
 
         var tasks = Enumerable.Range(0, totalOps)
-            .Select(_ => logSystem.LogAfterSecondsAsync(true, 0, p => Interlocked.Increment(ref progressCallbacksFired)))
+            .Select(_ => logSystem.LogAfterSecondsWithProgressAsync(true, 0, p => Interlocked.Increment(ref progressCallbacksFired)))
             .ToArray();
 
         for (var i = 0; i < 3; i++)

--- a/UnityProject/CspUnityTests/Assets/Scripts/IntegrationTests/Extensions/TestHelper.cs
+++ b/UnityProject/CspUnityTests/Assets/Scripts/IntegrationTests/Extensions/TestHelper.cs
@@ -135,7 +135,6 @@ namespace Magnopus.Foundation.Unity.Tests.Integration.Extensions
             var primaryEmail = primaryUsername + "@magnopus.com";
             var primaryUserPassword = $"{DateTime.Now.Ticks}{DateTime.Now.Ticks}";
             var primaryUserProfileResult = await userService.CreateUserAsync(
-                primaryUsername, 
                 displayName,
                 primaryEmail,
                 primaryUserPassword,false,true,string.Empty,string.Empty);

--- a/UnityProject/CspUnityTests/Assets/Scripts/IntegrationTests/User/LoginTests.cs
+++ b/UnityProject/CspUnityTests/Assets/Scripts/IntegrationTests/User/LoginTests.cs
@@ -44,12 +44,6 @@ namespace Magnopus.Foundation.Unity.Tests.Integration.User
             (HttpStatusCode.OK, true, ()=> GetTestUserProfile(TestUserProfileType.Primary).Email, ()=> GetTestUserProfile(TestUserProfileType.Primary).Password, true)
         };
 
-        private static (HttpStatusCode ExpectedCode, bool ExpectedReturnValue, Func<string> Password, bool UserHasVerifiedAge)[] loginAsUsernameValues = 
-        {
-            (HttpStatusCode.Forbidden, false, ()=> "password", false),
-            (HttpStatusCode.OK, true, ()=> GetTestUserProfile(TestUserProfileType.Primary).Password, true)
-        };
-
         private static (HttpStatusCode ExpectedCode, bool ExpectedReturnValue, string UserId, string Token)[] loginWithTokenValues = 
         {
             (HttpStatusCode.BadRequest, false, "userId", "token")
@@ -130,45 +124,6 @@ namespace Magnopus.Foundation.Unity.Tests.Integration.User
                 // Note: create multiplayer connection since we use online realtime engine, and no token option passed.
                 var loginResult = await TestHelper.WrapEndpoint(() => userService.LoginAsync(
                     value.Email?.Invoke(), value.Password?.Invoke(), true, value.UserHasVerifiedAge, null));
-                if (!TestHelper.IsSuccessCase(value.ExpectedCode))
-                {
-                    LogAssert.ignoreFailingMessages = false;
-                }
-
-                // Assert:
-                Assert.AreEqual((ushort)value.ExpectedCode, loginResult.ReturnCode);
-                Assert.AreEqual(!string.IsNullOrWhiteSpace(loginResult.ReturnData?.UserId), value.ExpectedReturnValue);
-
-                // Min wait between endpoint calls
-                await Task.Delay(ConfigSettings.MinWaitBetweenEndpointsMilliseconds);
-
-                if (TestHelper.IsSuccessCase(value.ExpectedCode))
-                {
-                    string authToken = userService.GetValidAuthToken();
-                    Assert.IsFalse(string.IsNullOrWhiteSpace(authToken));
-
-                    await userService.LogoutAsync();
-                    await Task.Delay(ConfigSettings.MinWaitBetweenEndpointsMilliseconds);
-                }
-            });
-
-        /// <summary>
-        /// Using the login with username and password endpoint with various params to get specific exceptions and success cases.
-        /// </summary>
-        [UnityTest]
-        public IEnumerator LoginAsUsernameCases([ValueSource(nameof(loginAsUsernameValues))] (HttpStatusCode ExpectedCode, bool ExpectedReturnValue, Func<string> Username, Func<string> Password, bool UserHasVerifiedAge) value)
-            => AsyncTest.RunAsync(async () =>
-            {
-                Assert.IsTrue(isInitialized);
-
-                // Action:
-                if (!TestHelper.IsSuccessCase(value.ExpectedCode))
-                {
-                    LogAssert.ignoreFailingMessages = true;
-                }
-                // Note: create multiplayer connection since we use online realtime engine, and no token option passed.
-                var loginResult = await TestHelper.WrapEndpoint(() => userService.LoginWithUsernameAsync(
-                    value.Username?.Invoke(), value.Password?.Invoke(), true, value.UserHasVerifiedAge, null));
                 if (!TestHelper.IsSuccessCase(value.ExpectedCode))
                 {
                     LogAssert.ignoreFailingMessages = false;

--- a/UnityProject/CspUnityTests/Assets/Scripts/IntegrationTests/User/ProfileTests.cs
+++ b/UnityProject/CspUnityTests/Assets/Scripts/IntegrationTests/User/ProfileTests.cs
@@ -29,12 +29,12 @@ namespace Magnopus.Foundation.Unity.Tests.Integration.User
             (HttpStatusCode.OK, true, ()=> LoginTests.GetTestUserProfile(TestUserProfileType.Primary).UserId)
         };
 
-        private static (HttpStatusCode ExpectedCode, bool ExpectedReturnValue, string Username, string DisplayName, Func<string> Email, string Password, bool ReceiveNewsletter, bool UserHasVerifiedAge, string RedirectUrl, string InviteToken)[] createUserValues = 
+        private static (HttpStatusCode ExpectedCode, bool ExpectedReturnValue, string DisplayName, Func<string> Email, string Password, bool ReceiveNewsletter, bool UserHasVerifiedAge, string RedirectUrl, string InviteToken)[] createUserValues = 
         {
-            (HttpStatusCode.Unauthorized, false, null, null, ()=> ConfigSettings.PrimaryUser.BaseUsername + DateTime.Now.Ticks + "@magnopus.com", null, false, false, null, null),
+            (HttpStatusCode.Unauthorized, false, null, ()=> ConfigSettings.PrimaryUser.BaseUsername + DateTime.Now.Ticks + "@magnopus.com", null, false, false, null, null),
             // Commenting out tests that use bad emails until we use seeded data
             //(HttpStatusCode.BadRequest, false, "username", "displayName", "email", "password", false, null)
-            (HttpStatusCode.Conflict, false, "username", "displayName", ()=> ConfigSettings.PrimaryUser.BaseUsername +  DateTime.Now.Ticks + "@magnopus.com", "password", false,true, null, null)
+            (HttpStatusCode.Conflict, false, "displayName", () => LoginTests.GetTestUserProfile(TestUserProfileType.Primary).Email, "password", false, true, null, null)
         };
 
         private static (HttpStatusCode ExpectedCode, string UserId)[] deleteUserValues = 
@@ -136,7 +136,7 @@ namespace Magnopus.Foundation.Unity.Tests.Integration.User
         /// Using the get profile by Id endpoint with various params to get specific exceptions and success cases.
         /// </summary>
         [UnityTest]
-        public IEnumerator CreateUserCases([ValueSource(nameof(createUserValues))] (HttpStatusCode ExpectedCode, bool ExpectedReturnValue, string Username,
+        public IEnumerator CreateUserCases([ValueSource(nameof(createUserValues))] (HttpStatusCode ExpectedCode, bool ExpectedReturnValue,
             string DisplayName, Func<string> Email, string Password, bool ReceiveNewsletter, bool UserHasVerifiedAge, string RedirectUrl, string InviteToken) value)
             => AsyncTest.RunAsync(async () =>
             {
@@ -147,7 +147,7 @@ namespace Magnopus.Foundation.Unity.Tests.Integration.User
                 {
                     LogAssert.ignoreFailingMessages = true;
                 }
-                var profileResult = await TestHelper.WrapEndpoint(() => userService.CreateUserAsync(value.Username, value.DisplayName, value.Email?.Invoke(), value.Password, value.ReceiveNewsletter, value.UserHasVerifiedAge, value.RedirectUrl, value.InviteToken));
+                var profileResult = await TestHelper.WrapEndpoint(() => userService.CreateUserAsync(value.DisplayName, value.Email?.Invoke(), value.Password, value.ReceiveNewsletter, value.UserHasVerifiedAge, value.RedirectUrl, value.InviteToken));
                 if (!TestHelper.IsSuccessCase(value.ExpectedCode))
                 {
                     LogAssert.ignoreFailingMessages = false;

--- a/UnityProject/CspUnityTests/Assets/Scripts/Runtime/User/IUserApi.cs
+++ b/UnityProject/CspUnityTests/Assets/Scripts/Runtime/User/IUserApi.cs
@@ -26,14 +26,12 @@ namespace Magnopus.Foundation.Unity.Runtime.User
         LoginState GetLoginState();
         Task<LoginInfo> LoginAsync(string email, string password, bool createMultiplayerConnection, 
             bool? userHasVerifiedAge, FoundationSystems.TokenOptions? tokenOptions);
-        Task<LoginInfo> LoginWithUsernameAsync(string username, string password, bool createMultiplayerConnection, 
-            bool? userHasVerifiedAge, FoundationSystems.TokenOptions? tokenOptions);
         Task<LoginInfo> LoginAsGuestAsync(bool createMultiplayerConnection, bool? guestHasVerifiedAge, FoundationSystems.TokenOptions? tokenOptions);
         Task<LoginInfo> LoginAsGuestWithDeferredProfileCreationAsync(bool? guestHasVerifiedAge);
         Task<LoginInfo> LoginWithTokenAsync(string userId, string token, bool createMultiplayerConnection, FoundationSystems.TokenOptions? tokenOptions);
         Task LogoutAsync();
         string GetValidAuthToken();
-        Task<Profile> CreateUserAsync(string username, string displayName, string email, string password, bool receiveNewsletter, bool userHasVerifiedAge, string redirectUrl, string inviteToken);
+        Task<Profile> CreateUserAsync(string displayName, string email, string password, bool receiveNewsletter, bool userHasVerifiedAge, string redirectUrl, string inviteToken);
         Task DeleteUserAsync(string userId);
         Task<Profile> GetProfileByIdAsync(string userId);
         Task<BasicProfile[]> GetProfilesByUserIdsAsync(string[] userIds);

--- a/UnityProject/CspUnityTests/Assets/Scripts/Runtime/User/UserApi.cs
+++ b/UnityProject/CspUnityTests/Assets/Scripts/Runtime/User/UserApi.cs
@@ -176,64 +176,6 @@ namespace Magnopus.Foundation.Unity.Runtime.User
         }
 
         /// <summary>
-        /// Requests the Foundation layer to Login with username and password.
-        /// May throw a <seealso cref="CspResultEndpointException"/> on error.
-        /// </summary>
-        /// <param name="username"> username of the user </param>
-        /// <param name="password"> password of the user </param>
-        /// <param name="createMultiplayerConnection">Whether to create a multiplayer connection.
-        /// If false, this session will not establish a SignalR connection to backend services, and thus be unable to
-        /// receive messages or events. This session will also be unable to enter online spaces via an OnlineRealtimeEngine.
-        /// If true, this session will receive events, and may enter both online and offline spaces.</param>
-        /// <param name="userHasVerifiedAge"> Optional: Whether the user has confirmed they are above the required age or not. Null if the user has not confirmed either.</param>
-        /// <param name="tokenOptions">Optional override for default token options.
-        /// The default token expiry length is configured by MCS and defaults to 30 minutes.
-        /// Value must be less than the default expiry length, or it will be ignored.</param>
-        /// <returns> Returns login information </returns>
-        public async Task<LoginInfo> LoginWithUsernameAsync(string username, string password, bool createMultiplayerConnection, 
-            bool? userHasVerifiedAge, FoundationSystems.TokenOptions? tokenOptions)
-        {
-            // TODO: https://magnopus.atlassian.net/browse/OF-207 don't check params once foundation does
-            if (string.IsNullOrWhiteSpace(username))
-            {
-                throw new CspResultEndpointException($"Did not login, parameter: {nameof(username)} was null.", HttpStatusCode.Unauthorized);
-            }
-
-            // TODO: https://magnopus.atlassian.net/browse/OF-207 don't check params once foundation does
-            if (string.IsNullOrWhiteSpace(password))
-            {
-                throw new CspResultEndpointException($"Did not login, parameter: {nameof(password)} was null.", HttpStatusCode.Unauthorized);
-            }
-
-            Debug.Log($"Logging in with Username {username} ...");
-
-            try
-            {
-                FoundationSystems.LoginStateResult loginResult = await userSystem.LoginAsync(string.Empty,
-                    password, createMultiplayerConnection, userHasVerifiedAge, tokenOptions);
-
-                FoundationCommon.LoginState result = loginResult.GetLoginState();
-                if (result == null)
-                {
-                    throw new CspResultEndpointException("Did not login, endpoint result was null.",
-                        HttpStatusCode.InternalServerError);
-                }
-
-                return result;
-            }
-            catch (CspResultEndpointException ex)
-            {
-                Debug.LogError($"Login failed: {ex.Message}");
-                throw;
-            }
-            catch (Exception ex)
-            {
-                Debug.LogError($"An unexpected error occurred during login: {ex}");
-                throw new CspResultEndpointException("An unexpected error occurred during login.", HttpStatusCode.InternalServerError, ex);
-            }
-        }
-
-        /// <summary>
         /// Requests the Foundation layer to Login as a guest.
         /// May throw a <seealso cref="CspResultEndpointException"/> on error.
         /// </summary>
@@ -410,7 +352,6 @@ namespace Magnopus.Foundation.Unity.Runtime.User
         /// Requests the Foundation layer to create a new account for the user using the given email and password.
         /// May throw a <seealso cref="CspResultEndpointException"/> on error.
         /// </summary>
-        /// <param name="username"> optional username of the new account. Set the Username if you want to be able to login using a username. </param>
         /// <param name="displayName"> visual name that other users may see when connected online </param>
         /// <param name="email"> email of the new account </param>
         /// <param name="password"> password of the new account </param>
@@ -419,14 +360,8 @@ namespace Magnopus.Foundation.Unity.Runtime.User
         /// <param name="redirectUrl"> optional: url used by the backend services to send the user to the desired page </param>
         /// <param name="inviteToken"> optional: token provided to the user that can be used to auto-confirm their account </param>
         /// <returns> the profile information of the created account </returns>
-        public async Task<Profile> CreateUserAsync(string username, string displayName, string email, string password, bool receiveNewsletter, bool userHasVerifiedAge, string redirectUrl, string inviteToken)
+        public async Task<Profile> CreateUserAsync(string displayName, string email, string password, bool receiveNewsletter, bool userHasVerifiedAge, string redirectUrl, string inviteToken)
         {
-            // TODO: https://magnopus.atlassian.net/browse/OF-207 don't check params once foundation does
-            if (string.IsNullOrWhiteSpace(username))
-            {
-                throw new CspResultEndpointException($"Did not create account, parameter: {nameof(username)} was null.", HttpStatusCode.Unauthorized);
-            }
-
             // TODO: https://magnopus.atlassian.net/browse/OF-207 don't check params once foundation does
             if (string.IsNullOrWhiteSpace(displayName))
             {


### PR DESCRIPTION
Task: https://magnopus.atlassian.net/browse/OPE-3282

Update Unity tests to remove outdated code for username, which is no longer in use for the current CSP version.

Tested in editor:

<img width="823" height="1031" alt="image" src="https://github.com/user-attachments/assets/7b87f9d4-4337-4aca-a71d-7739a82128dd" />
