### PR TITLE
[OPE-3282] Add missing action adapter and event definitions

### DIFF
--- a/interface/Declarations/AsyncDeclarations.i
+++ b/interface/Declarations/AsyncDeclarations.i
@@ -108,6 +108,13 @@ MAKE_ACTION_ADAPTER(ConversationUpdateCallback,
                      ARGLIST(csp.common.ConversationNetworkEventData),
                      ARGLIST(eventData));
 
+/* ComponentBase Action Adapters */
+MAKE_ACTION_ADAPTER(EntityActionHandler,
+                     EntityActionCallbackAdapter,
+                     ARGLIST(csp.multiplayer.ComponentBase component, string actionName, string actionParams),
+                     ARGLIST(csp.multiplayer.ComponentBase, string, string),
+                     ARGLIST(component, actionName, actionParams));
+
 /* AssetSystem Action Adapters */
 MAKE_ACTION_ADAPTER(AssetDetailBlobChangedCallback,
                      AssetDetailBlobChangedCallbackAdapter,

--- a/interface/Declarations/EventsDeclarations.i
+++ b/interface/Declarations/EventsDeclarations.i
@@ -175,6 +175,16 @@ MAKE_EVENT_FOR_CALLBACK(
     csp::systems::HotspotSequenceSystem
 )
 
+/* csp::systems::SequenceSystem events */
+
+MAKE_EVENT_FOR_CALLBACK(
+    OnSequenceChanged,
+    SequenceChangedCallback,
+    SetSequenceChangedCallback,
+    csp.common.SequenceChangedNetworkEventData,
+    csp::systems::SequenceSystem
+)
+
 /* csp::systems::SpaceSystem events */
 
 MAKE_EVENT_FOR_CALLBACK(


### PR DESCRIPTION
Task: https://magnopus.atlassian.net/browse/OPE-3282