### PR TITLE
Feat/OPE-3282 Fix macro definitions

### DIFF
--- a/interface/Declarations/AsyncDeclarations.i
+++ b/interface/Declarations/AsyncDeclarations.i
@@ -102,11 +102,18 @@ MAKE_ACTION_ADAPTER(EntityFetchCompleteCallback,
                      ARGLIST(numEntitiesFetched));
 
 /* ConversationSpaceComponent Action Adapters */
-MAKE_ACTION_ADAPTER(ConversationUpdateCallback,
+MAKE_ACTION_ADAPTER(ConversationNetworkEventCallback,
                      ConversationNetworkEventCallbackAdapter,
                      ARGLIST(csp.common.ConversationNetworkEventData eventData),
                      ARGLIST(csp.common.ConversationNetworkEventData),
                      ARGLIST(eventData));
+
+/* Asset Progress Action Adapter */
+MAKE_ACTION_ADAPTER(ProgressCallback,
+                     ProgressCallbackAdapter,
+                     ARGLIST(float progress),
+                     ARGLIST(float),
+                     ARGLIST(progress));
 
 /* ComponentBase Action Adapters */
 MAKE_ACTION_ADAPTER(EntityActionHandler,

--- a/interface/Declarations/CallbackDeclarations.i
+++ b/interface/Declarations/CallbackDeclarations.i
@@ -498,6 +498,12 @@ MAKE_CALLBACK(csp::multiplayer::ConversationSpaceComponent::ConversationUpdateCa
                       ARGLIST(csp::common::ConversationNetworkEventData eventData),
                       ARGLIST(eventData))
 
+/* Progress callback */
+MAKE_CALLBACK(csp::systems::ProgressCallback,
+              ProgressCallbackAdapter,
+              ARGLIST(float progress),
+              ARGLIST(progress))
+
 
 /*********** CALLBACK NAMESPACE ADAPTATION **********/
 /* First, know that callbacks (std::functions) are going through the Fulton transform (https://swig.org/Doc4.4/SWIGPlus.html)

--- a/interface/Declarations/EventsDeclarations.i
+++ b/interface/Declarations/EventsDeclarations.i
@@ -125,29 +125,6 @@ MAKE_EVENT_FOR_CALLBACK(
 )
 
 /* csp::systems::AssetSystem events */
-MAKE_EVENT_FOR_CALLBACK(
-    UploadAssetDataExOnProgress,
-    ProgressCallback,
-    SetUploadAssetDataExOnProgressCallback,
-    csp.ProgressEventArgs,
-    csp::systems::AssetSystem
-)
-
-MAKE_EVENT_FOR_CALLBACK(
-    UploadAssetDataOnProgress,
-    ProgressCallback,
-    SetUploadAssetDataOnProgressCallback,
-    csp.ProgressEventArgs,
-    csp::systems::AssetSystem
-)
-
-MAKE_EVENT_FOR_CALLBACK(
-    RegisterAssetToLODChainOnProgress,
-    ProgressCallback,
-    SetRegisterAssetToLODChainOnProgressCallback,
-    csp.ProgressEventArgs,
-    csp::systems::AssetSystem
-)
 
 MAKE_EVENT_FOR_CALLBACK(
     OnAssetDetailBlobChanged,


### PR DESCRIPTION
Task: https://magnopus.atlassian.net/browse/OPE-3282

Add missing declaration and adapter for progress callback, and fix ConversationNetworkEventCallback.
Remove macro declarations that were failing compilation due to the missing csp.ProgressEventArgs.