### PR TITLE
[OPE-3289] Ensure that required CSP libraries are provided on iOS and visionos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,16 @@ set_target_properties(${_WRAPPER_MODULE_NAME} PROPERTIES
 
 include(cmake/PackageInstall.cmake)
 
+# Do not remove this install directive.
+# Removing this causes Xcode "Undefined symbols for architecture arm64".
+if(APPLE)
+    if(CMAKE_SYSTEM_NAME STREQUAL "iOS" OR CMAKE_SYSTEM_NAME STREQUAL "visionOS")
+        # Copy the original CSP libraries alongside the one we created via SWIG
+        install(DIRECTORY "${_CSP_LIB_DIR}/"
+                DESTINATION "${INSTALL_DIR}/lib")
+    endif()
+endif()
+
 # If desired, automatically copy the generated code and libs into the Unity test project.
 if(COPY_OUTPUT_TO_UNITY_TEST_PROJECT)
   message(STATUS "\nStarting the copy of latest generated C# code and libraries to the Unity test project...")


### PR DESCRIPTION
Change in support of task https://magnopus.atlassian.net/browse/OPE-3289

Without doing this, we would cause undefined symbols errors when building for iOS and visionOS. CSP original libraries and SWIG generated ones need to coexist side-by-side for correct usage on iOS and visionOS.

Tested, this correctly produced once again the CSP libraries on the artifacts:

<img width="330" height="337" alt="image" src="https://github.com/user-attachments/assets/d9c6bb54-9727-49e5-b590-be767795d142" />
