### PR TITLE
Feat/OPE-3289 address changes to avoid crashes on client tests

### DIFF
--- a/interface/swigutils/AsyncAdapters.i
+++ b/interface/swigutils/AsyncAdapters.i
@@ -184,6 +184,10 @@ public sealed class ACTION_ADAPTER_TYPENAME : CALLBACKT
         {
             // If any other exception occurs, we set it on the task completion source. Failsafe.
             tcs.TrySetException(ex);
+
+            // Ensure the callback is safely unregistered and unpinned from the global 
+            // GCHandle registry if a validation exception interrupts the execution flow
+            callback.Invoked -= handler;
         }
     });
 

--- a/interface/swigutils/Exceptions.i
+++ b/interface/swigutils/Exceptions.i
@@ -12,3 +12,9 @@
     return $null;
   }
 }
+
+// -----------------------------------------------------------------------------
+// Global Zombie Pointer Safety Guard
+// Prevents dead SWIG proxy objects from passing invalid handles down to C++
+// -----------------------------------------------------------------------------
+%typemap(csin) SWIGTYPE * "($csinput != null && $csclassname.getCPtr($csinput).Handle == global::System.IntPtr.Zero) ? throw new global::System.ObjectDisposedException(\"$csinput\", \"Catastrophic Error: Cannot pass a zombie SWIG object with a deleted native pointer.\") : $csclassname.getCPtr($csinput)"

--- a/interface/swigutils/Exceptions.i
+++ b/interface/swigutils/Exceptions.i
@@ -14,7 +14,15 @@
 }
 
 // -----------------------------------------------------------------------------
-// Global Zombie Pointer Safety Guard
-// Prevents dead SWIG proxy objects from passing invalid handles down to C++
+// SWIG Managed-Side Disposal Guard
+//
+// Defensive check preventing the passing of C# SWIG proxies with null native handles
+// (already disposed in managed code) down to C++. 
+// 
+// IMPORTANT: This DOES NOT protect against C++-owned deletions (use-after-free) 
+// where the C# handle remains non-zero.
+//
+// If this exception is thrown, it indicates a bug in the calling C# code
+// (e.g., trying to use an object after it has been disposed).
 // -----------------------------------------------------------------------------
-%typemap(csin) SWIGTYPE * "($csinput != null && $csclassname.getCPtr($csinput).Handle == global::System.IntPtr.Zero) ? throw new global::System.ObjectDisposedException(\"$csinput\", \"Catastrophic Error: Cannot pass a zombie SWIG object with a deleted native pointer.\") : $csclassname.getCPtr($csinput)"
+%typemap(csin) SWIGTYPE * "($csinput != null && $csclassname.getCPtr($csinput).Handle == global::System.IntPtr.Zero) ? throw new global::System.ObjectDisposedException(\"$csinput\", \"Passed a disposed C# SWIG wrapper (null native handle) to C++. This indicates an object lifecycle bug needing investigation. Note: This does not detect C++-side deletions.\") : $csclassname.getCPtr($csinput)"


### PR DESCRIPTION
Change in support of task https://magnopus.atlassian.net/browse/OPE-3289.

The intent is to improve the stability and robustness of CSP APIs, so that:

-  instead of catastrophic failure when C# mistakenly tries to use a disposed C++ memory we have instead an exception thrown to C#, namely ObjectDisposedException. **Note though: while this is a defensive mechanism, it might mask design issues, so we accept this compromise at the moment because we can still have a way through exceptions to detect when that case applies.**

- when an exception is thrown with ThrowOnFailure, we make sure we also unsubscribe the callback as it won't be reused by any code once the async function completes.