### PR TITLE
Feat/OPE-3289 Add support for ci and batch download of libs

### DIFF
--- a/UnityProject/extra/Editor/CSPLibraryDownloader.cs
+++ b/UnityProject/extra/Editor/CSPLibraryDownloader.cs
@@ -234,13 +234,13 @@ namespace Plugins.Editor
                     {
                         string tempDownloadPath = Path.Combine(Application.temporaryCachePath, "csp_binaries.tgz");
                         
-                        using (UnityWebRequest www = UnityWebRequest.Get(data.downloadUrl))
+                        try
                         {
-                            www.downloadHandler = new DownloadHandlerFile(tempDownloadPath);
-                            var operation = www.SendWebRequest();
-
-                            try
+                            using (UnityWebRequest www = UnityWebRequest.Get(data.downloadUrl))
                             {
+                                www.downloadHandler = new DownloadHandlerFile(tempDownloadPath);
+                                var operation = www.SendWebRequest();
+
                                 while (!operation.isDone)
                                 {
                                     bool isCanceled = EditorUtility.DisplayCancelableProgressBar(
@@ -258,45 +258,42 @@ namespace Plugins.Editor
                                     await Task.Delay(100);
                                 }
 
-                                EditorUtility.ClearProgressBar();
-
-                                if (www.result == UnityWebRequest.Result.Success)
-                                {
-                                    ExtractTarball(tempDownloadPath, localPluginsPath);
-                                    CleanupRedundantFiles(localPluginsPath);
-                                    File.Create(targetVersionFile).Dispose();
-
-                                    AssetDatabase.Refresh();
-                                    Debug.Log($"[CSP] Successfully installed native binaries version: {data.version}");
-                                    
-                                    if (forceManual)
-                                    {
-                                        EditorUtility.DisplayDialog("Success", $"CSP Binaries ({data.version}) successfully installed.", "OK");
-                                    }
-                                }
-                                else
+                                if (www.result != UnityWebRequest.Result.Success)
                                 {
                                     throw new LibraryInstallationException($"Network error: {www.error}");
                                 }
-                            }
-                            catch (Exception)
-                            {
-                                throw;
-                            }
-                            finally
-                            {
-                                EditorUtility.ClearProgressBar();
                                 
-                                if (File.Exists(tempDownloadPath)) 
+                                var handler = www.downloadHandler;
+                                www.downloadHandler = null;
+                                handler?.Dispose();
+                            }
+                            
+                            EditorUtility.ClearProgressBar();
+                            ExtractTarball(tempDownloadPath, localPluginsPath);
+                            CleanupRedundantFiles(localPluginsPath);
+                            File.Create(targetVersionFile).Dispose();
+
+                            AssetDatabase.Refresh();
+                            Debug.Log($"[CSP] Successfully installed native binaries version: {data.version}");
+                            
+                            if (forceManual)
+                            {
+                                EditorUtility.DisplayDialog("Success", $"CSP Binaries ({data.version}) successfully installed.", "OK");
+                            }
+                        }
+                        finally
+                        {
+                            EditorUtility.ClearProgressBar();
+                            
+                            if (File.Exists(tempDownloadPath)) 
+                            {
+                                try
                                 {
-                                    try
-                                    {
-                                        File.Delete(tempDownloadPath);
-                                    }
-                                    catch
-                                    {
-                                        // Ignore cleanup errors
-                                    }
+                                    File.Delete(tempDownloadPath);
+                                }
+                                catch
+                                {
+                                    // Ignore cleanup errors
                                 }
                             }
                         }
@@ -305,7 +302,7 @@ namespace Plugins.Editor
             }
             finally
             {
-                // Always release the lock, even if an exception was thrown or the user canceled
+                // Always release the mutual exclusion lock
                 _isWorkflowRunning = false;
             }
         }

--- a/UnityProject/extra/Editor/CSPLibraryDownloader.cs
+++ b/UnityProject/extra/Editor/CSPLibraryDownloader.cs
@@ -86,39 +86,52 @@ namespace Plugins.Editor
                 Debug.Log($"[CSP-CI] Missing binaries (Target: {data.version}). Starting download...");
                 string tempDownloadPath = Path.Combine(Application.temporaryCachePath, "csp_binaries.tgz");
 
-                // Isolate ONLY the HTTP network stream to a background thread to prevent Unity API deadlocks
-                Task.Run(async () =>
+                try
                 {
-                    using (HttpClient client = new HttpClient())
+                    // Isolate ONLY the HTTP network stream to a background thread to prevent Unity API deadlocks
+                    Task.Run(async () =>
                     {
-                        using (HttpResponseMessage response = await client.GetAsync(data.downloadUrl, HttpCompletionOption.ResponseHeadersRead))
+                        using (HttpClient client = new HttpClient())
                         {
-                            response.EnsureSuccessStatusCode();
-                            
-                            using (Stream contentStream = await response.Content.ReadAsStreamAsync())
+                            using (HttpResponseMessage response = await client.GetAsync(data.downloadUrl, HttpCompletionOption.ResponseHeadersRead))
                             {
-                                using (Stream fileStream = new FileStream(tempDownloadPath, FileMode.Create, FileAccess.Write, FileShare.None, 8192, true))
+                                response.EnsureSuccessStatusCode();
+                                
+                                using (Stream contentStream = await response.Content.ReadAsStreamAsync())
                                 {
-                                    await contentStream.CopyToAsync(fileStream);
+                                    using (Stream fileStream = new FileStream(tempDownloadPath, FileMode.Create, FileAccess.Write, FileShare.None, 8192, true))
+                                    {
+                                        await contentStream.CopyToAsync(fileStream);
+                                    }
                                 }
                             }
                         }
-                    }
-                }).GetAwaiter().GetResult();
+                    }).GetAwaiter().GetResult();
 
-                Debug.Log("[CSP-CI] Download complete. Processing...");
-                
-                // Back on the Main Thread safely: Extract and call Unity APIs
-                ExtractTarball(tempDownloadPath, localPluginsPath);
-                CleanupRedundantFiles(localPluginsPath);
-                File.Create(targetVersionFile).Dispose();
+                    Debug.Log("[CSP-CI] Download complete. Processing...");
+                    
+                    // Back on the Main Thread safely: Extract and call Unity APIs
+                    ExtractTarball(tempDownloadPath, localPluginsPath);
+                    CleanupRedundantFiles(localPluginsPath);
+                    File.Create(targetVersionFile).Dispose();
 
-                AssetDatabase.Refresh();
-                Debug.Log($"[CSP-CI] Successfully installed native binaries version: {data.version}");
-
-                if (File.Exists(tempDownloadPath))
+                    AssetDatabase.Refresh();
+                    Debug.Log($"[CSP-CI] Successfully installed native binaries version: {data.version}");
+                }
+                finally
                 {
-                    File.Delete(tempDownloadPath);
+                    // Ensure cleanup happens on all success and failure paths
+                    if (File.Exists(tempDownloadPath))
+                    {
+                        try
+                        {
+                            File.Delete(tempDownloadPath);
+                        }
+                        catch
+                        {
+                            // Ignore cleanup errors to prevent masking the original exception
+                        }
+                    }
                 }
             }
         }

--- a/UnityProject/extra/Editor/CSPLibraryDownloader.cs
+++ b/UnityProject/extra/Editor/CSPLibraryDownloader.cs
@@ -46,8 +46,18 @@ namespace Plugins.Editor
             }
             else
             {
-                // Safely fire-and-forget in the background without freezing the UI.
-                EditorApplication.delayCall += () => _ = RunEditorWorkflowAsync(false);
+                // Safely await the workflow inside an async lambda so exceptions are observed
+                EditorApplication.delayCall += async () =>
+                {
+                    try
+                    {
+                        await RunEditorWorkflowAsync(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.LogError($"[CSP] Automatic binary download failed during editor initialization: {ex.Message}\n{ex.StackTrace}");
+                    }
+                };
             }
         }
 
@@ -169,7 +179,7 @@ namespace Plugins.Editor
             {
                 if (forceManual)
                 {
-                    Debug.LogError($"Metadata not found at {metadataPath}. Ensure package is installed.");
+                    throw new LibraryInstallationException($"Metadata not found at {metadataPath}. Ensure package is installed.");
                 }
 
                 return;
@@ -245,13 +255,12 @@ namespace Plugins.Editor
                             }
                             else
                             {
-                                Debug.LogError($"[CSP] Network error: {www.error}");
-                                EditorUtility.DisplayDialog("Download Failed", www.error, "OK");
+                                throw new LibraryInstallationException($"Network error: {www.error}");
                             }
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
-                            Debug.LogException(e);
+                            throw;
                         }
                         finally
                         {

--- a/UnityProject/extra/Editor/CSPLibraryDownloader.cs
+++ b/UnityProject/extra/Editor/CSPLibraryDownloader.cs
@@ -93,6 +93,9 @@ namespace Plugins.Editor
                     {
                         using (HttpClient client = new HttpClient())
                         {
+                            // Disable the default 100-second timeout for large artifact downloads
+                            client.Timeout = System.Threading.Timeout.InfiniteTimeSpan;
+
                             using (HttpResponseMessage response = await client.GetAsync(data.downloadUrl, HttpCompletionOption.ResponseHeadersRead))
                             {
                                 response.EnsureSuccessStatusCode();

--- a/UnityProject/extra/Editor/CSPLibraryDownloader.cs
+++ b/UnityProject/extra/Editor/CSPLibraryDownloader.cs
@@ -54,7 +54,19 @@ namespace Plugins.Editor
         [MenuItem(MenuPath)]
         public static async void ManualDownloadTrigger()
         {
-            await RunEditorWorkflowAsync(true);
+            try
+            {
+                await RunEditorWorkflowAsync(true);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[CSP] Manual binary download failed: {ex.Message}\n{ex.StackTrace}");
+                UnityEditor.EditorUtility.DisplayDialog(
+                    "CSP Binary Download Failed", 
+                    $"An error occurred while downloading or extracting the native binaries.\n\n{ex.Message}\n\nCheck the Unity Console for more details.", 
+                    "OK"
+                );
+            }
         }
 
         // --- DEDICATED CI PIPELINE (Deadlock Free) ---

--- a/UnityProject/extra/Editor/CSPLibraryDownloader.cs
+++ b/UnityProject/extra/Editor/CSPLibraryDownloader.cs
@@ -14,6 +14,9 @@ namespace Plugins.Editor
         private const string PackageName = "com.magnopus.csp.unity";
         private const string MenuPath = "MAGNOPUS/Download CSP Libraries";
 
+        // Mutual exclusion lock to prevent concurrent downloads from editor and manual triggers
+        private static bool _isWorkflowRunning = false;
+
         // A targeted custom exception for our downstream catchers
         public class LibraryInstallationException : Exception
         {
@@ -115,8 +118,8 @@ namespace Plugins.Editor
                     {
                         using (HttpClient client = new HttpClient())
                         {
-                            // Disable the default 100-second timeout for large artifact downloads
-                            client.Timeout = System.Threading.Timeout.InfiniteTimeSpan;
+                            // A large, finite timeout prevents CI jobs from hanging indefinitely on stalled networks
+                            client.Timeout = TimeSpan.FromMinutes(10);
 
                             using (HttpResponseMessage response = await client.GetAsync(data.downloadUrl, HttpCompletionOption.ResponseHeadersRead))
                             {
@@ -164,122 +167,146 @@ namespace Plugins.Editor
         // --- DEDICATED EDITOR PIPELINE (UI Responsive) ---
         private static async Task RunEditorWorkflowAsync(bool forceManual)
         {
-            string packagePath = Path.GetFullPath($"Packages/{PackageName}");
-            var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath($"Packages/{PackageName}");
-            
-            if (packageInfo != null)
-            {
-                packagePath = packageInfo.resolvedPath; 
-            }
-
-            string metadataPath = Path.Combine(packagePath, "package-dist.json");
-            string localPluginsPath = Path.Combine(Application.dataPath, "Plugins/CSP/Internal");
-
-            if (!File.Exists(metadataPath))
+            // Prevent concurrent executions
+            if (_isWorkflowRunning)
             {
                 if (forceManual)
                 {
-                    throw new LibraryInstallationException($"Metadata not found at {metadataPath}. Ensure package is installed.");
+                    EditorUtility.DisplayDialog(
+                        "Download in Progress", 
+                        "A download or extraction is already in progress. Please wait for it to complete.", 
+                        "OK"
+                    );
                 }
-
                 return;
             }
 
-            DistributionMetadata data = ReadMetadata(metadataPath);
-
-            // Check if the folder exists and if the specific target version marker exists
-            string targetVersionFile = Path.Combine(localPluginsPath, $".version-{data.version}");
-            
-            bool needsDownload = !Directory.Exists(localPluginsPath) || !File.Exists(targetVersionFile) || forceManual;
-
-            if (needsDownload)
+            try
             {
-                bool proceed = true;
+                _isWorkflowRunning = true; // Lock the workflow
 
-                if (forceManual)
+                string packagePath = Path.GetFullPath($"Packages/{PackageName}");
+                var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath($"Packages/{PackageName}");
+                
+                if (packageInfo != null)
                 {
-                    proceed = EditorUtility.DisplayDialog(
-                        "Download CSP Binaries",
-                        $"Force download native binaries ({data.version})?\n\nThis will download approx 780MB from GitHub.",
-                        "Download",
-                        "Cancel");
-                }
-                else
-                {
-                    Debug.Log($"[CSP] Outdated or missing binaries detected (Target: {data.version}). Starting download...");
+                    packagePath = packageInfo.resolvedPath; 
                 }
 
-                if (proceed)
+                string metadataPath = Path.Combine(packagePath, "package-dist.json");
+                string localPluginsPath = Path.Combine(Application.dataPath, "Plugins/CSP/Internal");
+
+                if (!File.Exists(metadataPath))
                 {
-                    string tempDownloadPath = Path.Combine(Application.temporaryCachePath, "csp_binaries.tgz");
-                    
-                    using (UnityWebRequest www = UnityWebRequest.Get(data.downloadUrl))
+                    if (forceManual)
                     {
-                        www.downloadHandler = new DownloadHandlerFile(tempDownloadPath);
-                        var operation = www.SendWebRequest();
+                        throw new LibraryInstallationException($"Metadata not found at {metadataPath}. Ensure package is installed.");
+                    }
 
-                        try
+                    return;
+                }
+
+                DistributionMetadata data = ReadMetadata(metadataPath);
+
+                // Check if the folder exists and if the specific target version marker exists
+                string targetVersionFile = Path.Combine(localPluginsPath, $".version-{data.version}");
+                
+                bool needsDownload = !Directory.Exists(localPluginsPath) || !File.Exists(targetVersionFile) || forceManual;
+
+                if (needsDownload)
+                {
+                    bool proceed = true;
+
+                    if (forceManual)
+                    {
+                        proceed = EditorUtility.DisplayDialog(
+                            "Download CSP Binaries",
+                            $"Force download native binaries ({data.version})?\n\nThis will download approx 780MB from GitHub.",
+                            "Download",
+                            "Cancel");
+                    }
+                    else
+                    {
+                        Debug.Log($"[CSP] Outdated or missing binaries detected (Target: {data.version}). Starting download...");
+                    }
+
+                    if (proceed)
+                    {
+                        string tempDownloadPath = Path.Combine(Application.temporaryCachePath, "csp_binaries.tgz");
+                        
+                        using (UnityWebRequest www = UnityWebRequest.Get(data.downloadUrl))
                         {
-                            while (!operation.isDone)
-                            {
-                                bool isCanceled = EditorUtility.DisplayCancelableProgressBar(
-                                    "Downloading CSP Binaries", 
-                                    $"Fetching assets... {Mathf.RoundToInt(www.downloadProgress * 100)}%", 
-                                    www.downloadProgress);
+                            www.downloadHandler = new DownloadHandlerFile(tempDownloadPath);
+                            var operation = www.SendWebRequest();
 
-                                if (isCanceled)
+                            try
+                            {
+                                while (!operation.isDone)
                                 {
-                                    www.Abort(); 
-                                    Debug.LogWarning("[CSP] Binary download canceled by user.");
-                                    return; 
+                                    bool isCanceled = EditorUtility.DisplayCancelableProgressBar(
+                                        "Downloading CSP Binaries", 
+                                        $"Fetching assets... {Mathf.RoundToInt(www.downloadProgress * 100)}%", 
+                                        www.downloadProgress);
+
+                                    if (isCanceled)
+                                    {
+                                        www.Abort(); 
+                                        Debug.LogWarning("[CSP] Binary download canceled by user.");
+                                        return; 
+                                    }
+                                    
+                                    await Task.Delay(100);
                                 }
+
+                                EditorUtility.ClearProgressBar();
+
+                                if (www.result == UnityWebRequest.Result.Success)
+                                {
+                                    ExtractTarball(tempDownloadPath, localPluginsPath);
+                                    CleanupRedundantFiles(localPluginsPath);
+                                    File.Create(targetVersionFile).Dispose();
+
+                                    AssetDatabase.Refresh();
+                                    Debug.Log($"[CSP] Successfully installed native binaries version: {data.version}");
+                                    
+                                    if (forceManual)
+                                    {
+                                        EditorUtility.DisplayDialog("Success", $"CSP Binaries ({data.version}) successfully installed.", "OK");
+                                    }
+                                }
+                                else
+                                {
+                                    throw new LibraryInstallationException($"Network error: {www.error}");
+                                }
+                            }
+                            catch (Exception)
+                            {
+                                throw;
+                            }
+                            finally
+                            {
+                                EditorUtility.ClearProgressBar();
                                 
-                                await Task.Delay(100);
-                            }
-
-                            EditorUtility.ClearProgressBar();
-
-                            if (www.result == UnityWebRequest.Result.Success)
-                            {
-                                ExtractTarball(tempDownloadPath, localPluginsPath);
-                                CleanupRedundantFiles(localPluginsPath);
-                                File.Create(targetVersionFile).Dispose();
-
-                                AssetDatabase.Refresh();
-                                Debug.Log($"[CSP] Successfully installed native binaries version: {data.version}");
-                                
-                                if (forceManual)
+                                if (File.Exists(tempDownloadPath)) 
                                 {
-                                    EditorUtility.DisplayDialog("Success", $"CSP Binaries ({data.version}) successfully installed.", "OK");
-                                }
-                            }
-                            else
-                            {
-                                throw new LibraryInstallationException($"Network error: {www.error}");
-                            }
-                        }
-                        catch (Exception)
-                        {
-                            throw;
-                        }
-                        finally
-                        {
-                            EditorUtility.ClearProgressBar();
-                            
-                            if (File.Exists(tempDownloadPath)) 
-                            {
-                                try
-                                {
-                                    File.Delete(tempDownloadPath);
-                                }
-                                catch
-                                {
-                                    // Ignore cleanup errors
+                                    try
+                                    {
+                                        File.Delete(tempDownloadPath);
+                                    }
+                                    catch
+                                    {
+                                        // Ignore cleanup errors
+                                    }
                                 }
                             }
                         }
                     }
                 }
+            }
+            finally
+            {
+                // Always release the lock, even if an exception was thrown or the user canceled
+                _isWorkflowRunning = false;
             }
         }
 

--- a/UnityProject/extra/Editor/CSPLibraryDownloader.cs
+++ b/UnityProject/extra/Editor/CSPLibraryDownloader.cs
@@ -276,15 +276,23 @@ namespace Plugins.Editor
 
         private static DistributionMetadata ReadMetadata(string path)
         {
-            string json = File.ReadAllText(path);
-            var data = JsonUtility.FromJson<DistributionMetadata>(json);
-
-            if (data == null || string.IsNullOrEmpty(data.downloadUrl))
+            try
             {
-                throw new LibraryInstallationException("downloadUrl is empty in package-dist.json");
-            }
+                string json = File.ReadAllText(path);
+                var data = JsonUtility.FromJson<DistributionMetadata>(json);
 
-            return data;
+                if (data == null || string.IsNullOrEmpty(data.downloadUrl))
+                {
+                    throw new LibraryInstallationException("downloadUrl is empty in package-dist.json");
+                }
+
+                return data;
+            }
+            catch (Exception ex)
+            {
+                throw new LibraryInstallationException(
+                    $"Failed to read or parse metadata at path: '{path}'.\nUnderlying error: {ex.Message}", ex);
+            }
         }
 
         private static void ExtractTarball(string archivePath, string targetFolder)

--- a/UnityProject/extra/Editor/CSPLibraryDownloader.cs
+++ b/UnityProject/extra/Editor/CSPLibraryDownloader.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -15,236 +17,255 @@ namespace Plugins.Editor
         // A targeted custom exception for our downstream catchers
         public class LibraryInstallationException : Exception
         {
-            public LibraryInstallationException(string message) : base(message) { }
-            public LibraryInstallationException(string message, Exception innerException) : base(message, innerException) { }
+            public LibraryInstallationException(string message) : base(message)
+            {
+            }
+
+            public LibraryInstallationException(string message, Exception innerException) : base(message, innerException)
+            {
+            }
         }
 
         static CSPBinaryDownloader()
         {
-            // Check for binaries shortly after the editor opens
-            EditorApplication.delayCall += () => CheckForMissingBinaries(false);
+            if (Application.isBatchMode)
+            {
+                Debug.Log("[CSP-CI] Batch mode detected on startup. Checking for binaries...");
+                
+                try
+                {
+                    // Run the dedicated synchronous CI pipeline
+                    RunCIWorkflow();
+                    Debug.Log("[CSP-CI] CI Initialization complete. Proceeding with batch tasks...");
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"[CSP-CI] FATAL ERROR during CI binary download: {e}");
+                    EditorApplication.Exit(1); 
+                }
+            }
+            else
+            {
+                // Safely fire-and-forget in the background without freezing the UI.
+                EditorApplication.delayCall += () => _ = RunEditorWorkflowAsync(false);
+            }
         }
 
         [MenuItem(MenuPath)]
-        public static void ManualDownloadTrigger()
+        public static async void ManualDownloadTrigger()
         {
-            CheckForMissingBinaries(true);
+            await RunEditorWorkflowAsync(true);
         }
 
-        public static void CheckForMissingBinaries(bool forceManual)
+        // --- DEDICATED CI PIPELINE (Deadlock Free) ---
+        private static void RunCIWorkflow()
         {
             string packagePath = Path.GetFullPath($"Packages/{PackageName}");
+            var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath($"Packages/{PackageName}");
+            
+            if (packageInfo != null)
+            {
+                packagePath = packageInfo.resolvedPath; 
+            }
+
             string metadataPath = Path.Combine(packagePath, "package-dist.json");
         
             // Target: Assets/Plugins/CSP/Internal (Unity has write access here)
             string localPluginsPath = Path.Combine(Application.dataPath, "Plugins/CSP/Internal");
 
-            bool binariesExist = Directory.Exists(localPluginsPath) && 
-                                 Directory.GetFiles(localPluginsPath, "*", SearchOption.AllDirectories).Length > 0;
-
-            if (!binariesExist || forceManual)
+            if (!File.Exists(metadataPath))
             {
-                if (!File.Exists(metadataPath))
-                {
-                    if (forceManual) Debug.LogError($"Metadata not found at {metadataPath}. Ensure package is installed via Git.");
-                    return;
-                }
+                throw new LibraryInstallationException($"Metadata missing at {metadataPath}");
+            }
 
-                DistributionMetadata data;
-                try
+            DistributionMetadata data = ReadMetadata(metadataPath);
+            string targetVersionFile = Path.Combine(localPluginsPath, $".version-{data.version}");
+            
+            if (!Directory.Exists(localPluginsPath) || !File.Exists(targetVersionFile))
+            {
+                Debug.Log($"[CSP-CI] Missing binaries (Target: {data.version}). Starting download...");
+                string tempDownloadPath = Path.Combine(Application.temporaryCachePath, "csp_binaries.tgz");
+
+                // Isolate ONLY the HTTP network stream to a background thread to prevent Unity API deadlocks
+                Task.Run(async () =>
                 {
-                    data = ReadMetadata(metadataPath);
-                }
-                catch (LibraryInstallationException e)
-                {
-                    Debug.LogException(e);
-                    if (forceManual)
+                    using (HttpClient client = new HttpClient())
                     {
-                        EditorUtility.DisplayDialog("Error", e.Message, "OK");
+                        using (HttpResponseMessage response = await client.GetAsync(data.downloadUrl, HttpCompletionOption.ResponseHeadersRead))
+                        {
+                            response.EnsureSuccessStatusCode();
+                            
+                            using (Stream contentStream = await response.Content.ReadAsStreamAsync())
+                            {
+                                using (Stream fileStream = new FileStream(tempDownloadPath, FileMode.Create, FileAccess.Write, FileShare.None, 8192, true))
+                                {
+                                    await contentStream.CopyToAsync(fileStream);
+                                }
+                            }
+                        }
                     }
-                    return;
+                }).GetAwaiter().GetResult();
+
+                Debug.Log("[CSP-CI] Download complete. Processing...");
+                
+                // Back on the Main Thread safely: Extract and call Unity APIs
+                ExtractTarball(tempDownloadPath, localPluginsPath);
+                CleanupRedundantFiles(localPluginsPath);
+                File.Create(targetVersionFile).Dispose();
+
+                AssetDatabase.Refresh();
+                Debug.Log($"[CSP-CI] Successfully installed native binaries version: {data.version}");
+
+                if (File.Exists(tempDownloadPath))
+                {
+                    File.Delete(tempDownloadPath);
+                }
+            }
+        }
+
+        // --- DEDICATED EDITOR PIPELINE (UI Responsive) ---
+        private static async Task RunEditorWorkflowAsync(bool forceManual)
+        {
+            string packagePath = Path.GetFullPath($"Packages/{PackageName}");
+            var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath($"Packages/{PackageName}");
+            
+            if (packageInfo != null)
+            {
+                packagePath = packageInfo.resolvedPath; 
+            }
+
+            string metadataPath = Path.Combine(packagePath, "package-dist.json");
+            string localPluginsPath = Path.Combine(Application.dataPath, "Plugins/CSP/Internal");
+
+            if (!File.Exists(metadataPath))
+            {
+                if (forceManual)
+                {
+                    Debug.LogError($"Metadata not found at {metadataPath}. Ensure package is installed.");
                 }
 
-                bool proceed = forceManual || EditorUtility.DisplayDialog(
-                    "CSP Binaries Missing",
-                    $"The {PackageName} package requires native binaries ({data.version}).\n\nDownload approx 780MB from GitHub?",
-                    "Download", "Skip");
+                return;
+            }
+
+            DistributionMetadata data = ReadMetadata(metadataPath);
+
+            // Check if the folder exists and if the specific target version marker exists
+            string targetVersionFile = Path.Combine(localPluginsPath, $".version-{data.version}");
+            
+            bool needsDownload = !Directory.Exists(localPluginsPath) || !File.Exists(targetVersionFile) || forceManual;
+
+            if (needsDownload)
+            {
+                bool proceed = true;
+
+                if (forceManual)
+                {
+                    proceed = EditorUtility.DisplayDialog(
+                        "Download CSP Binaries",
+                        $"Force download native binaries ({data.version})?\n\nThis will download approx 780MB from GitHub.",
+                        "Download",
+                        "Cancel");
+                }
+                else
+                {
+                    Debug.Log($"[CSP] Outdated or missing binaries detected (Target: {data.version}). Starting download...");
+                }
 
                 if (proceed)
                 {
-                    StartEditorDownload(data.downloadUrl, localPluginsPath);
+                    string tempDownloadPath = Path.Combine(Application.temporaryCachePath, "csp_binaries.tgz");
+                    
+                    using (UnityWebRequest www = UnityWebRequest.Get(data.downloadUrl))
+                    {
+                        www.downloadHandler = new DownloadHandlerFile(tempDownloadPath);
+                        var operation = www.SendWebRequest();
+
+                        try
+                        {
+                            while (!operation.isDone)
+                            {
+                                bool isCanceled = EditorUtility.DisplayCancelableProgressBar(
+                                    "Downloading CSP Binaries", 
+                                    $"Fetching assets... {Mathf.RoundToInt(www.downloadProgress * 100)}%", 
+                                    www.downloadProgress);
+
+                                if (isCanceled)
+                                {
+                                    www.Abort(); 
+                                    Debug.LogWarning("[CSP] Binary download canceled by user.");
+                                    return; 
+                                }
+                                
+                                await Task.Delay(100);
+                            }
+
+                            EditorUtility.ClearProgressBar();
+
+                            if (www.result == UnityWebRequest.Result.Success)
+                            {
+                                ExtractTarball(tempDownloadPath, localPluginsPath);
+                                CleanupRedundantFiles(localPluginsPath);
+                                File.Create(targetVersionFile).Dispose();
+
+                                AssetDatabase.Refresh();
+                                Debug.Log($"[CSP] Successfully installed native binaries version: {data.version}");
+                                
+                                if (forceManual)
+                                {
+                                    EditorUtility.DisplayDialog("Success", $"CSP Binaries ({data.version}) successfully installed.", "OK");
+                                }
+                            }
+                            else
+                            {
+                                Debug.LogError($"[CSP] Network error: {www.error}");
+                                EditorUtility.DisplayDialog("Download Failed", www.error, "OK");
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            Debug.LogException(e);
+                        }
+                        finally
+                        {
+                            EditorUtility.ClearProgressBar();
+                            
+                            if (File.Exists(tempDownloadPath)) 
+                            {
+                                try
+                                {
+                                    File.Delete(tempDownloadPath);
+                                }
+                                catch
+                                {
+                                    // Ignore cleanup errors
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
 
         private static DistributionMetadata ReadMetadata(string path)
         {
-            try
+            string json = File.ReadAllText(path);
+            var data = JsonUtility.FromJson<DistributionMetadata>(json);
+
+            if (data == null || string.IsNullOrEmpty(data.downloadUrl))
             {
-                string json = File.ReadAllText(path);
-                var data = JsonUtility.FromJson<DistributionMetadata>(json);
-                
-                if (data == null || string.IsNullOrEmpty(data.downloadUrl))
-                    throw new LibraryInstallationException("downloadUrl is empty or malformed in package-dist.json");
-                    
-                return data;
+                throw new LibraryInstallationException("downloadUrl is empty in package-dist.json");
             }
-            catch (IOException e)
-            {
-                throw new LibraryInstallationException($"Failed to read metadata file at {path}", e);
-            }
-            catch (ArgumentException e)
-            {
-                throw new LibraryInstallationException($"Failed to parse JSON in metadata file at {path}", e);
-            }
-        }
 
-        private static void StartEditorDownload(string url, string targetPath)
-        {
-            UnityWebRequest www = UnityWebRequest.Get(url);
-            www.SendWebRequest();
-
-            // Standard Editor Update loop to handle the download without blocking the UI
-            EditorApplication.CallbackFunction updateAction = null;
-            updateAction = () =>
-            {
-                bool shouldCleanup = false;
-
-                try
-                {
-                    if (www == null) 
-                    {
-                        shouldCleanup = true;
-                        return;
-                    }
-
-                    if (!www.isDone)
-                    {
-                        bool isCanceled = EditorUtility.DisplayCancelableProgressBar(
-                            "Downloading CSP", 
-                            $"Fetching binaries... {Mathf.RoundToInt(www.downloadProgress * 100)}%", 
-                            www.downloadProgress);
-
-                        if (isCanceled)
-                        {
-                            www.Abort(); 
-                            shouldCleanup = true;
-                            Debug.Log("CSP Binary download was canceled by the user.");
-                        }
-                        return; // Exit normally, wait for next frame
-                    }
-
-                    // If we reach here, the download naturally finished
-                    shouldCleanup = true;
-
-                    if (www.result == UnityWebRequest.Result.Success)
-                    {
-                        ProcessDownload(www.downloadHandler.data, targetPath);
-                    }
-                    else
-                    {
-                        var webEx = new LibraryInstallationException($"Network error during download: {www.error}");
-                        Debug.LogException(webEx);
-                        EditorUtility.DisplayDialog("Download Failed", $"Could not download binaries: {www.error}", "OK");
-                    }
-                }
-                catch (Exception e)
-                {
-                    // Catch any unexpected errors so they don't break the Editor
-                    Debug.LogException(e);
-                    shouldCleanup = true; 
-                }
-                finally
-                {
-                    // This guarantees the UI is unblocked and memory is freed, 
-                    // but ONLY when the process is actually terminating!
-                    if (shouldCleanup)
-                    {
-                        EditorUtility.ClearProgressBar();
-                        EditorApplication.update -= updateAction;
-                        
-                        if (www != null)
-                        {
-                            www.Dispose();
-                            www = null; // Null it out to prevent double-disposal
-                        }
-                    }
-                }
-            };
-
-            EditorApplication.update += updateAction;
-        }
-
-        private static void ProcessDownload(byte[] data, string targetFolder)
-        {
-            string tempPath = Path.Combine(Application.temporaryCachePath, "csp_binaries.tgz");
-            
-            try 
-            {
-                SaveTarball(data, tempPath);
-                ExtractTarball(tempPath, targetFolder);
-                CleanupRedundantFiles(targetFolder);
-
-                AssetDatabase.Refresh();
-                EditorUtility.DisplayDialog("Success", "CSP Binaries successfully installed.", "OK");
-            }
-            catch (LibraryInstallationException e)
-            {
-                Debug.LogException(e);
-                EditorUtility.DisplayDialog("Extraction Error", $"Failed to install binaries:\n{e.Message}", "OK");
-            }
-            finally
-            {
-                if (File.Exists(tempPath)) 
-                {
-                    try
-                    {
-                        File.Delete(tempPath);
-                    }
-                    catch (DirectoryNotFoundException)
-                    {
-                        // don't care
-                    }
-                    catch (Exception e)
-                    {
-                        Debug.LogException(e);
-                    }
-                }
-            }
-        }
-
-        private static void SaveTarball(byte[] data, string savePath)
-        {
-            try
-            {
-                File.WriteAllBytes(savePath, data);
-            }
-            catch (IOException e)
-            {
-                throw new LibraryInstallationException($"Could not write temporary tarball to {savePath}", e);
-            }
-            catch (UnauthorizedAccessException e)
-            {
-                throw new LibraryInstallationException($"Access denied when writing to {savePath}", e);
-            }
+            return data;
         }
 
         private static void ExtractTarball(string archivePath, string targetFolder)
         {
-            try 
+            if (!Directory.Exists(targetFolder))
             {
-                if (!Directory.Exists(targetFolder))
-                {
-                    Directory.CreateDirectory(targetFolder);
-                }
-            }
-            catch (Exception e)
-            {
-                throw new LibraryInstallationException($"Failed to create target directory {targetFolder}", e);
+                Directory.CreateDirectory(targetFolder);
             }
 
-            Debug.Log($"Extracting to {targetFolder}...");
-            
             // Uses system 'tar' (Available on Win 10+, macOS, Linux)
             System.Diagnostics.ProcessStartInfo startInfo = new System.Diagnostics.ProcessStartInfo
             {
@@ -258,9 +279,13 @@ namespace Plugins.Editor
             {
                 using (var process = System.Diagnostics.Process.Start(startInfo))
                 {
-                    if (process == null) throw new LibraryInstallationException("Failed to initialize tar process.");
+                    if (process == null)
+                    {
+                        throw new LibraryInstallationException("Failed to initialize tar process.");
+                    }
                     
                     process.WaitForExit();
+
                     if (process.ExitCode != 0)
                     {
                         throw new LibraryInstallationException($"Tar extraction failed with exit code {process.ExitCode}");
@@ -279,19 +304,32 @@ namespace Plugins.Editor
             {
                 // Remove duplicated C# source folders that were included in the tarball
                 string[] redundantDirs = { "Runtime", "Editor" };
+
                 foreach (string dir in redundantDirs)
                 {
                     string path = Path.Combine(targetFolder, dir);
-                    if (Directory.Exists(path)) Directory.Delete(path, true);
-                    if (File.Exists(path + ".meta")) File.Delete(path + ".meta");
+
+                    if (Directory.Exists(path)) 
+                    {
+                        Directory.Delete(path, true);
+                    }
+
+                    if (File.Exists(path + ".meta")) 
+                    {
+                        File.Delete(path + ".meta");
+                    }
                 }
 
-                // Remove package manifests so they don't clutter the project
                 string[] redundantFiles = { "package.json", "package.json.meta", "package-dist.json", "package-dist.json.meta" };
+
                 foreach (string file in redundantFiles)
                 {
                     string path = Path.Combine(targetFolder, file);
-                    if (File.Exists(path)) File.Delete(path);
+
+                    if (File.Exists(path))
+                    { 
+                        File.Delete(path);
+                    }
                 }
             }
             catch (IOException e)

--- a/Utilities/CI/generate_unity_meta.py
+++ b/Utilities/CI/generate_unity_meta.py
@@ -19,12 +19,13 @@ def generate_meta(file_path: Path, package_root: Path, is_directory: bool):
     guid = get_guid(rel_path_str)
 
     if is_directory:
+        # Empty string quotes added to prevent Git whitespace stripping
         body = ("folderAsset: yes\n"
                 "DefaultImporter:\n"
                 "  externalObjects: {}\n"
-                "  userData: \n"
-                "  assetBundleName: \n"
-                "  assetBundleVariant: ")
+                "  userData: ''\n"
+                "  assetBundleName: ''\n"
+                "  assetBundleVariant: ''")
     elif file_path.suffix == '.cs':
         body = ("MonoImporter:\n"
                 "  externalObjects: {}\n"
@@ -47,7 +48,7 @@ def generate_meta(file_path: Path, package_root: Path, is_directory: bool):
                 "  validateReferences: 1\n"
                 "  platformData:\n"
                 "  - first:\n"
-                "      Any: \n"
+                "      Any: ''\n"
                 "    second:\n"
                 "      enabled: 0\n"
                 "      settings:\n"
@@ -62,9 +63,9 @@ def generate_meta(file_path: Path, package_root: Path, is_directory: bool):
                 "      enabled: 1\n"
                 "      settings:\n"
                 "        CPU: ARM64\n"
-                "  userData: \n"
-                "  assetBundleName: \n"
-                "  assetBundleVariant: ")
+                "  userData: ''\n"
+                "  assetBundleName: ''\n"
+                "  assetBundleVariant: ''")
     elif file_path.suffix == '.a' and 'visionOS' in file_path.parts:
         # Determine if this binary is for the Simulator or Device based on its folder
         sdk_target = 'Simulator' if 'Simulator' in file_path.parts else 'Device'
@@ -81,7 +82,7 @@ def generate_meta(file_path: Path, package_root: Path, is_directory: bool):
                 "  validateReferences: 1\n"
                 "  platformData:\n"
                 "  - first:\n"
-                "      Any: \n"
+                "      Any: ''\n"
                 "    second:\n"
                 "      enabled: 0\n"
                 "      settings:\n"
@@ -97,15 +98,16 @@ def generate_meta(file_path: Path, package_root: Path, is_directory: bool):
                 "      settings:\n"
                 "        CPU: ARM64\n"
                 f"        SDK: {sdk_target}\n"
-                "  userData: \n"
-                "  assetBundleName: \n"
-                "  assetBundleVariant: ")
+                "  userData: ''\n"
+                "  assetBundleName: ''\n"
+                "  assetBundleVariant: ''")
     else:
+        # Empty string quotes added to prevent Git whitespace stripping
         body = ("DefaultImporter:\n"
                 "  externalObjects: {}\n"
-                "  userData: \n"
-                "  assetBundleName: \n"
-                "  assetBundleVariant: ")
+                "  userData: ''\n"
+                "  assetBundleName: ''\n"
+                "  assetBundleVariant: ''")
 
     content = f"fileFormatVersion: 2\nguid: {guid}\n{body}\n"
 

--- a/Utilities/CI/generate_unity_meta.py
+++ b/Utilities/CI/generate_unity_meta.py
@@ -19,7 +19,7 @@ def generate_meta(file_path: Path, package_root: Path, is_directory: bool):
     guid = get_guid(rel_path_str)
 
     if is_directory:
-        # Empty string quotes added to prevent Git whitespace stripping
+        # Use explicit empty strings to avoid trailing whitespace and YAML empty-scalar warnings
         body = ("folderAsset: yes\n"
                 "DefaultImporter:\n"
                 "  externalObjects: {}\n"
@@ -102,7 +102,7 @@ def generate_meta(file_path: Path, package_root: Path, is_directory: bool):
                 "  assetBundleName: ''\n"
                 "  assetBundleVariant: ''")
     else:
-        # Empty string quotes added to prevent Git whitespace stripping
+        # Use explicit empty strings to avoid trailing whitespace and YAML empty-scalar warnings
         body = ("DefaultImporter:\n"
                 "  externalObjects: {}\n"
                 "  userData: ''\n"


### PR DESCRIPTION
Change in support of task https://magnopus.atlassian.net/browse/OPE-3289

Summary:

- Update libraries download process to be compatible with batch mode and CI. This allows us to have the libs in place before CI pipelines would trigger builds or test executions.
- Update python script that generates the Unity meta files to avoid YAML warnings.

Testing:

I executed a batch script and confirmed that the plugin blocks the execution until the libs download is completed. The following is the type of messages showing up:

```
[CSP-CI] Batch mode detected on startup. Checking for binaries...
...
[CSP-CI] Missing binaries (Target: 0.0.5). Starting download...
...
[CSP-CI] Download complete. Processing...
...
[CSP-CI] Successfully installed native binaries version: 0.0.5
...
[CSP-CI] CI Initialization complete. Proceeding with TeamCity tasks...
```

The script:

/Applications/Unity/Hub/Editor/6000.0.70f1/Unity.app/Contents/MacOS/Unity -batchmode -nographics -quit -projectPath "PATH_TO_PROJECT" -logFile /dev/stdout && echo "--- UNITY EXITED: NOW RUNNING TEAMCITY BUILD STEP ---"