### PR TITLE
[OPE-3289] Remove null assignment to resolve failure

### DIFF
--- a/UnityProject/extra/Editor/CSPLibraryDownloader.cs
+++ b/UnityProject/extra/Editor/CSPLibraryDownloader.cs
@@ -262,10 +262,6 @@ namespace Plugins.Editor
                                 {
                                     throw new LibraryInstallationException($"Network error: {www.error}");
                                 }
-                                
-                                var handler = www.downloadHandler;
-                                www.downloadHandler = null;
-                                handler?.Dispose();
                             }
                             
                             EditorUtility.ClearProgressBar();


### PR DESCRIPTION
This resolves the following exception:

CSP] Automatic binary download failed during editor initialization: UnityWebRequest has already been sent; cannot modify the download handler
  at UnityEngine.Networking.UnityWebRequest.set_downloadHandler (UnityEngine.Networking.DownloadHandler value) [0x0000e] in /Users/bokken/build/output/unity/unity/Modules/UnityWebRequest/Public/UnityWebRequest.bindings.cs:604
  at Plugins.Editor.CSPBinaryDownloader.RunEditorWorkflowAsync (System.Boolean forceManual) [0x00385] in ./Library/PackageCache/com.magnopus.csp.unity@5cf6eca2bdb6/Editor/CSPLibraryDownloader.cs:267