### PR TITLE
[OPE-3289] Fix unrecognised scalar error in YAML

### DIFF
--- a/Utilities/CI/generate_unity_meta.py
+++ b/Utilities/CI/generate_unity_meta.py
@@ -31,7 +31,7 @@ def generate_meta(file_path: Path, package_root: Path, is_directory: bool):
                 "  externalObjects: {}\n"
                 "  serializedVersion: 2\n"
                 "  iconMap: {}\n"
-                "  executionOrder: 0")
+                "  executionOrder: {}")
     elif file_path.suffix == '.so':
         # Safely target Android native plugins, strictly assigning ARM64 and Preload.
         # The preload makes sure that when the app looks for CSP it finds the lib in memory already loaded at startup.
@@ -40,7 +40,7 @@ def generate_meta(file_path: Path, package_root: Path, is_directory: bool):
                 "  externalObjects: {}\n"
                 "  serializedVersion: 2\n"
                 "  iconMap: {}\n"
-                "  executionOrder: 0\n"
+                "  executionOrder: {}\n"
                 "  defineConstraints: []\n"
                 "  isPreloaded: 1\n"
                 "  isOverridable: 0\n"
@@ -74,7 +74,7 @@ def generate_meta(file_path: Path, package_root: Path, is_directory: bool):
                 "  externalObjects: {}\n"
                 "  serializedVersion: 2\n"
                 "  iconMap: {}\n"
-                "  executionOrder: 0\n"
+                "  executionOrder: {}\n"
                 "  defineConstraints: []\n"
                 "  isPreloaded: 0\n"
                 "  isOverridable: 0\n"


### PR DESCRIPTION
PR in support of https://magnopus.atlassian.net/browse/OPE-3289

The change corrects a malformed value in the YAML of the meta files generated by our python script. This resolves the following error:

YAML error in '___.meta' - Unexpected scalar when reading mapping.
03:00:09   UnityEngine.Debug:ExtractStackTraceNoAlloc (byte*,int,string)
03:00:09   UnityEngine.StackTraceUtility:ExtractStackTrace () (at /Users/bokken/build/output/unity/unity/Runtime/Export/Scripting/StackTrace.cs:35)
03:00:09   Magnopus.OKO.Build.Editor.AutomatedBuilds:BuildPlayer () (at /Users/automaton/TCA/work/a4e1c8fe85e643df/common/oko.build/Editor/AutomatedBuilds.cs:155)