### PR TITLE
[OPE-3289] Fix executionOrder confusing formatting

### DIFF
--- a/Utilities/CI/generate_unity_meta.py
+++ b/Utilities/CI/generate_unity_meta.py
@@ -13,7 +13,6 @@ def generate_meta(file_path: Path, package_root: Path, is_directory: bool):
     if meta_path.exists():
         return
 
-
     # Everything is relative to the root (forced to forward slashes)
     rel_path_str = file_path.relative_to(package_root).as_posix()
     guid = get_guid(rel_path_str)
@@ -27,15 +26,18 @@ def generate_meta(file_path: Path, package_root: Path, is_directory: bool):
                 "  assetBundleName: ''\n"
                 "  assetBundleVariant: ''")
     elif file_path.suffix == '.cs':
+        # Explicitly set executionOrder to scalar 0 for C# scripts (MonoImporter)
+        # Added the standard trailing fields so Unity sees a complete file
         body = ("MonoImporter:\n"
                 "  externalObjects: {}\n"
                 "  serializedVersion: 2\n"
                 "  iconMap: {}\n"
-                "  executionOrder: {}")
+                "  executionOrder: 0\n")
     elif file_path.suffix == '.so':
         # Safely target Android native plugins, strictly assigning ARM64 and Preload.
         # The preload makes sure that when the app looks for CSP it finds the lib in memory already loaded at startup.
         # Without the preload, a dll not found error could arise if not resolved some other way via code.
+        # Native plugins (PluginImporter) use an empty mapping {} for executionOrder
         body = ("PluginImporter:\n"
                 "  externalObjects: {}\n"
                 "  serializedVersion: 2\n"
@@ -70,6 +72,7 @@ def generate_meta(file_path: Path, package_root: Path, is_directory: bool):
         # Determine if this binary is for the Simulator or Device based on its folder
         sdk_target = 'Simulator' if 'Simulator' in file_path.parts else 'Device'
 
+        # Native plugins (PluginImporter) use an empty mapping {} for executionOrder
         body = ("PluginImporter:\n"
                 "  externalObjects: {}\n"
                 "  serializedVersion: 2\n"


### PR DESCRIPTION
Unity expects the field executionOrder as int for scripts but as {} for lirbaries. Unfortunately the previous fix we applied seemed to be uniform for both cases, which is now causing this other issue:

Error while extracting property 'MonoImporter.executionOrder' from file 'Packages/com.magnopus.csp.unity/Runtime/AddShopifyStoreResultCallbackAdapter.cs.meta' (error = 'Expected scalar value for int')
 Outputting YAML:
 fileFormatVersion: 2
 guid: 4335514abcd78f5112ed07e31e24e18a
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   iconMap: {}
   executionOrder: {}

This commit should fix it by distinguishing the two cases explicitly.