### PR TITLE
[OB-5651] Enable downcasting of Material to derived types in SWIG wrapper

### DIFF
--- a/interface/CSP/Systems/Assets/AlphaVideoMaterial.i
+++ b/interface/CSP/Systems/Assets/AlphaVideoMaterial.i
@@ -4,4 +4,7 @@
 
 ADD_OUTER_OBJECT_PIN_SLOT(csp::systems::AlphaVideoMaterial)
 
+%include "swigutils/FromBaseCast.i"
+MAKE_FROM_BASE_CAST(csp::systems::AlphaVideoMaterial, csp::systems::Material, csp.systems.AlphaVideoMaterial, csp.systems.Material)
+
 %include "CSP/Systems/Assets/AlphaVideoMaterial.h"

--- a/interface/CSP/Systems/Assets/GLTFMaterial.i
+++ b/interface/CSP/Systems/Assets/GLTFMaterial.i
@@ -4,4 +4,7 @@
 
 ADD_OUTER_OBJECT_PIN_SLOT(csp::systems::GLTFMaterial)
 
+%include "swigutils/FromBaseCast.i"
+MAKE_FROM_BASE_CAST(csp::systems::GLTFMaterial, csp::systems::Material, csp.systems.GLTFMaterial, csp.systems.Material)
+
 %include "CSP/Systems/Assets/GLTFMaterial.h"


### PR DESCRIPTION
### Ticket

https://magnopus.atlassian.net/browse/OB-5651

### Changes
Enable downcasting of Material to derived types in SWIG wrapper

MaterialResult only ever returns a base Material wrapper, so consumers
lost the derived data (colours, textures, alpha mode). Apply the existing
MAKE_FROM_BASE_CAST macro to GLTFMaterial and AlphaVideoMaterial so they
can be downcast from a base Material, matching how ComponentBase is handled.

### Testing

<img width="412" height="317" alt="image" src="https://github.com/user-attachments/assets/0a674f2c-3924-4096-9220-e70df0017d99" />

- Ran unity test project tests
- Tested in Untiy Editor by manually copying over generated C# files and libs, and ignoring all errors-as-warnings in the editor with the `csc.rsp` file.