### PR TITLE
OPE-3046: Patch For CSP 6.46

### DIFF
--- a/interface/Declarations/CallbackDeclarations.i
+++ b/interface/Declarations/CallbackDeclarations.i
@@ -461,6 +461,26 @@ MAKE_CALLBACK(csp::multiplayer::NetworkEventBus::ErrorCodeCallbackHandler,
                       ErrorCodeCallbackAdapter,
                       ARGLIST(csp::multiplayer::ErrorCode errorCode),
                       ARGLIST(errorCode))
+MAKE_CALLBACK(csp::multiplayer::AccessControlChangedEventCallback,
+                      AccessControlChangedEventCallbackAdapter,
+                      ARGLIST(csp::common::AccessControlChangedNetworkEventData accessControlChangedNetworkEventData),
+                      ARGLIST(accessControlChangedNetworkEventData))
+MAKE_CALLBACK(csp::multiplayer::AssetDetailBlobChangedEventCallback,
+                      AssetDetailBlobChangedEventCallbackAdapter,
+                      ARGLIST(csp::common::AssetDetailBlobChangedNetworkEventData assetDetailBlobChangedNetworkEventData),
+                      ARGLIST(assetDetailBlobChangedNetworkEventData))
+MAKE_CALLBACK(csp::multiplayer::AsyncCallCompletedEventCallback,
+                      AsyncCallCompletedEventCallbackAdapter,
+                      ARGLIST(csp::common::AsyncCallCompletedEventData asyncCallCompletedEventData),
+                      ARGLIST(asyncCallCompletedEventData))
+MAKE_CALLBACK(csp::multiplayer::ConversationEventCallback,
+                      ConversationEventCallbackAdapter,
+                      ARGLIST(csp::common::ConversationNetworkEventData conversationNetworkEventData),
+                      ARGLIST(conversationNetworkEventData))
+MAKE_CALLBACK(csp::multiplayer::SequenceChangedEventCallback,
+                      SequenceChangedEventCallbackAdapter,
+                      ARGLIST(csp::common::SequenceChangedNetworkEventData sequenceChangedNetworkEventData),
+                      ARGLIST(sequenceChangedNetworkEventData))
 
 //ComponentBase
 MAKE_CALLBACK(csp::multiplayer::ComponentBase::EntityActionHandler,

--- a/interface/Declarations/CallbackDeclarations.i
+++ b/interface/Declarations/CallbackDeclarations.i
@@ -463,24 +463,24 @@ MAKE_CALLBACK(csp::multiplayer::NetworkEventBus::ErrorCodeCallbackHandler,
                       ARGLIST(errorCode))
 MAKE_CALLBACK(csp::multiplayer::AccessControlChangedEventCallback,
                       AccessControlChangedEventCallbackAdapter,
-                      ARGLIST(csp::common::AccessControlChangedNetworkEventData accessControlChangedNetworkEventData),
-                      ARGLIST(accessControlChangedNetworkEventData))
+                      ARGLIST(csp::common::AccessControlChangedNetworkEventData eventData),
+                      ARGLIST(eventData))
 MAKE_CALLBACK(csp::multiplayer::AssetDetailBlobChangedEventCallback,
                       AssetDetailBlobChangedEventCallbackAdapter,
-                      ARGLIST(csp::common::AssetDetailBlobChangedNetworkEventData assetDetailBlobChangedNetworkEventData),
-                      ARGLIST(assetDetailBlobChangedNetworkEventData))
+                      ARGLIST(csp::common::AssetDetailBlobChangedNetworkEventData eventData),
+                      ARGLIST(eventData))
 MAKE_CALLBACK(csp::multiplayer::AsyncCallCompletedEventCallback,
                       AsyncCallCompletedEventCallbackAdapter,
-                      ARGLIST(csp::common::AsyncCallCompletedEventData asyncCallCompletedEventData),
-                      ARGLIST(asyncCallCompletedEventData))
+                      ARGLIST(csp::common::AsyncCallCompletedEventData eventData),
+                      ARGLIST(eventData))
 MAKE_CALLBACK(csp::multiplayer::ConversationEventCallback,
                       ConversationEventCallbackAdapter,
-                      ARGLIST(csp::common::ConversationNetworkEventData conversationNetworkEventData),
-                      ARGLIST(conversationNetworkEventData))
+                      ARGLIST(csp::common::ConversationNetworkEventData eventData),
+                      ARGLIST(eventData))
 MAKE_CALLBACK(csp::multiplayer::SequenceChangedEventCallback,
                       SequenceChangedEventCallbackAdapter,
-                      ARGLIST(csp::common::SequenceChangedNetworkEventData sequenceChangedNetworkEventData),
-                      ARGLIST(sequenceChangedNetworkEventData))
+                      ARGLIST(csp::common::SequenceChangedNetworkEventData eventData),
+                      ARGLIST(eventData))
 
 //ComponentBase
 MAKE_CALLBACK(csp::multiplayer::ComponentBase::EntityActionHandler,


### PR DESCRIPTION
### Ticket

https://magnopus.atlassian.net/browse/OPE-3406

### Summary Of Changes

- Added callback adapters for the new network event bus events.

### Testing

Ran /Utilities/Build/build-Mac.sh and ensured that the following adapters were generated:

- /build/generated/cs
   - AccessControlChangedEventCallbackAdapter.cs
   - AssetDetailBlobChangedEventCallbackAdapter.cs
   - AsyncCallCompletedEventCallbackAdapter.cs
   - ConversationEventCallbackAdapter.cs
   - SequenceChangedEventCallbackAdapter.cs

CSP compare here: https://github.com/magnopus-opensource/connected-spaces-platform/compare/v6.45.0...v6.46.0
