### PR TITLE
OPE-3046: Second Patch For CSP 6.46

### DIFF
--- a/interface/Declarations/AsyncDeclarations.i
+++ b/interface/Declarations/AsyncDeclarations.i
@@ -135,13 +135,6 @@ MAKE_ACTION_ADAPTER(MaterialChangedCallback,
                      ARGLIST(csp.common.MaterialChangedParams),
                      ARGLIST(materialParams));
 
-/* SpaceSystem Action Adapters */
-MAKE_ACTION_ADAPTER(AsyncCallCompletedCallback,
-                     AsyncCallCompletedCallbackAdapter,
-                     ARGLIST(csp.common.AsyncCallCompletedEventData eventData),
-                     ARGLIST(csp.common.AsyncCallCompletedEventData),
-                     ARGLIST(eventData));
-
 /* UserSystem Action Adapters */
 MAKE_ACTION_ADAPTER(LoginTokenInfoCallback,
                      LoginTokenInfoResultCallbackAdapter,
@@ -175,7 +168,31 @@ MAKE_ACTION_ADAPTER(CustomNetworkEventCallback,
                      ARGLIST(csp.common.NetworkEventData networkEventData),
                      ARGLIST(csp.common.NetworkEventData),
                      ARGLIST(networkEventData));
-
+MAKE_ACTION_ADAPTER(AccessControlChangedEventCallback,
+                     AccessControlChangedEventCallbackAdapter,
+                     ARGLIST(csp.common.AccessControlChangedEventData eventData),
+                     ARGLIST(csp.common.AccessControlChangedEventData),
+                     ARGLIST(eventData));
+MAKE_ACTION_ADAPTER(AssetDetailBlobChangedEventCallback,
+                     AssetDetailBlobChangedEventCallbackAdapter,
+                     ARGLIST(csp.common.AssetDetailBlobChangedNetworkEventData eventData),
+                     ARGLIST(csp.common.AssetDetailBlobChangedNetworkEventData),
+                     ARGLIST(eventData));
+MAKE_ACTION_ADAPTER(AsyncCallCompletedEventCallback,
+                     AsyncCallCompletedEventCallbackAdapter,
+                     ARGLIST(csp.common.AsyncCallCompletedEventData eventData),
+                     ARGLIST(csp.common.AsyncCallCompletedEventData),
+                     ARGLIST(eventData));
+MAKE_ACTION_ADAPTER(ConversationEventCallback,
+                     ConversationEventCallbackAdapter,
+                     ARGLIST(csp.common.ConversationEventData eventData),
+                     ARGLIST(csp.common.ConversationEventData),
+                     ARGLIST(eventData));
+MAKE_ACTION_ADAPTER(SequenceChangedEventCallback,
+                     SequenceChangedEventCallbackAdapter,
+                     ARGLIST(csp.common.SequenceChangedEventData eventData),
+                     ARGLIST(csp.common.SequenceChangedEventData),
+                     ARGLIST(eventData));
 
 /* 
  * Now stamp out Async adapters.

--- a/interface/Declarations/AsyncDeclarations.i
+++ b/interface/Declarations/AsyncDeclarations.i
@@ -170,8 +170,8 @@ MAKE_ACTION_ADAPTER(CustomNetworkEventCallback,
                      ARGLIST(networkEventData));
 MAKE_ACTION_ADAPTER(AccessControlChangedEventCallback,
                      AccessControlChangedEventCallbackAdapter,
-                     ARGLIST(csp.common.AccessControlChangedEventData eventData),
-                     ARGLIST(csp.common.AccessControlChangedEventData),
+                     ARGLIST(csp.common.AccessControlChangedNetworkEventData eventData),
+                     ARGLIST(csp.common.AccessControlChangedNetworkEventData),
                      ARGLIST(eventData));
 MAKE_ACTION_ADAPTER(AssetDetailBlobChangedEventCallback,
                      AssetDetailBlobChangedEventCallbackAdapter,
@@ -185,13 +185,13 @@ MAKE_ACTION_ADAPTER(AsyncCallCompletedEventCallback,
                      ARGLIST(eventData));
 MAKE_ACTION_ADAPTER(ConversationEventCallback,
                      ConversationEventCallbackAdapter,
-                     ARGLIST(csp.common.ConversationEventData eventData),
-                     ARGLIST(csp.common.ConversationEventData),
+                     ARGLIST(csp.common.ConversationNetworkEventData eventData),
+                     ARGLIST(csp.common.ConversationNetworkEventData),
                      ARGLIST(eventData));
 MAKE_ACTION_ADAPTER(SequenceChangedEventCallback,
                      SequenceChangedEventCallbackAdapter,
-                     ARGLIST(csp.common.SequenceChangedEventData eventData),
-                     ARGLIST(csp.common.SequenceChangedEventData),
+                     ARGLIST(csp.common.SequenceChangedNetworkEventData eventData),
+                     ARGLIST(csp.common.SequenceChangedNetworkEventData),
                      ARGLIST(eventData));
 
 /* 


### PR DESCRIPTION
### Ticket

https://magnopus.atlassian.net/browse/OPE-3406

### Summary Of Changes

- Added async action adapters for the new network event bus events.

### Testing

Ran /Utilities/Build/build-Mac.sh and ensured that the following actions were generated:

- /build/generated/cs/ConnectedSpacePlatformDotNet.cs
   - AccessControlChangedEventCallback
   - AssetDetailBlobChangedEventCallback
   - AsyncCallCompletedEventCallback
   - ConversationEventCallback
   - SequenceChangedEventCallback

CSP compare here: https://github.com/magnopus-opensource/connected-spaces-platform/compare/v6.45.0...v6.46.0
